### PR TITLE
Add responsive coaching log frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# Coaches-log
+# Coaches Log
+
+A lightweight, mobile-friendly coaching session tracker that stores data locally in the browser. The main screen focuses on capturing a session quickly with pre-filled dropdowns that stay in sync with your reference data lists.
+
+## Features
+
+- **Session logging** – Capture the essentials (date, coach, coachee, session type, focus area, status, duration, notes) with a single tap-friendly form.
+- **Reference data maintenance** – Manage coaches, coachees, session types, focus areas and statuses. Lists feed all dropdowns so the form always stays current.
+- **Session history** – Filter previous sessions by coach, coachee, status, or date and export everything as JSON for external reporting.
+- **Today view** – Glance at sessions scheduled or completed today without leaving the main screen.
+- **Offline-first** – All information is saved in `localStorage`; no backend services required.
+
+## Getting started
+
+1. Open `index.html` in any modern browser (mobile Safari/Chrome supported).
+2. Add or edit reference data if needed (Reference data tab).
+3. Log a session from the main form – default options are pre-selected to accelerate data entry.
+4. Review or export the full history from the Sessions tab.
+
+> Tip: To start fresh, clear the browser's site data or run the app in a private/incognito window.
+
+## Tech stack
+
+- Vanilla HTML, CSS and JavaScript (no build step required)
+- Responsive layout optimized for phones and tablets
+- Local storage persistence

--- a/app.js
+++ b/app.js
@@ -1,0 +1,608 @@
+const STORAGE_KEY = 'coaching-log-state-v1';
+
+const defaultState = {
+  referenceData: {
+    coaches: ['Alex Morgan', 'Priya Patel', 'Jonas Eriksen'],
+    coachees: ['Jordan Lee', 'Mina Chen', 'Samuel Ortiz', 'Taylor Brooks'],
+    sessionTypes: ['1:1 Coaching', 'Career Planning', 'Onboarding Support', 'Performance Review'],
+    focusAreas: ['Leadership', 'Communication', 'Strategy', 'Well-being'],
+    statuses: ['Scheduled', 'Completed', 'Rescheduled', 'Cancelled'],
+  },
+  sessions: [],
+};
+
+const categories = {
+  coaches: {
+    label: 'Coaches',
+    singular: 'Coach',
+    description: 'People delivering the coaching conversations.',
+    addLabel: 'Add coach',
+  },
+  coachees: {
+    label: 'Coachees',
+    singular: 'Coachee',
+    description: 'Individuals receiving coaching.',
+    addLabel: 'Add coachee',
+  },
+  sessionTypes: {
+    label: 'Session types',
+    singular: 'Session type',
+    description: 'Formats of the coaching conversation.',
+    addLabel: 'Add session type',
+  },
+  focusAreas: {
+    label: 'Focus areas',
+    singular: 'Focus area',
+    description: 'Themes or goals discussed.',
+    addLabel: 'Add focus area',
+  },
+  statuses: {
+    label: 'Statuses',
+    singular: 'Status',
+    description: 'Stage of each session.',
+    addLabel: 'Add status',
+  },
+};
+
+function deepClone(value) {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+let appState = loadState();
+let currentFilters = {
+  coach: '',
+  coachee: '',
+  status: '',
+  date: '',
+};
+
+const views = document.querySelectorAll('.view');
+const navButtons = document.querySelectorAll('.nav__item');
+const appNav = document.getElementById('app-nav');
+const menuToggle = document.getElementById('menu-toggle');
+const toastEl = document.getElementById('toast');
+
+const sessionForm = document.getElementById('session-form');
+const sessionDateInput = document.getElementById('session-date');
+const sessionCoachSelect = document.getElementById('session-coach');
+const sessionCoacheeSelect = document.getElementById('session-coachee');
+const sessionTypeSelect = document.getElementById('session-type');
+const sessionFocusSelect = document.getElementById('session-focus');
+const sessionStatusSelect = document.getElementById('session-status');
+
+const quickRefreshButton = document.getElementById('quick-refresh');
+const todaySessionsList = document.getElementById('today-sessions');
+const todayEmptyState = document.getElementById('today-empty');
+
+const referenceSectionsEl = document.getElementById('reference-sections');
+
+const filterForm = document.getElementById('filter-form');
+const filterCoachSelect = document.getElementById('filter-coach');
+const filterCoacheeSelect = document.getElementById('filter-coachee');
+const filterStatusSelect = document.getElementById('filter-status');
+const filterDateInput = document.getElementById('filter-date');
+const clearFiltersButton = document.getElementById('clear-filters');
+const sessionsList = document.getElementById('sessions-list');
+const exportJsonButton = document.getElementById('export-json');
+
+init();
+
+function init() {
+  attachNavigationHandlers();
+  attachMenuToggle();
+  menuToggle.setAttribute('aria-expanded', 'false');
+  const defaultButton = document.querySelector('.nav__item--active') || navButtons[0];
+  if (defaultButton) {
+    activateView(defaultButton.dataset.target, defaultButton);
+  }
+  attachSessionFormHandlers();
+  attachQuickViewHandlers();
+  attachFilterHandlers();
+  attachExportHandler();
+  renderReferenceSections();
+  refreshSelectOptions();
+  setDefaultFormValues();
+  renderSessionList();
+  renderTodaySessions();
+}
+
+function loadState() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      const referenceData = {
+        ...defaultState.referenceData,
+        ...(parsed.referenceData || {}),
+      };
+      const sessions = Array.isArray(parsed.sessions) ? parsed.sessions : [];
+      return {
+        referenceData: deepClone(referenceData),
+        sessions: deepClone(sessions),
+      };
+    }
+  } catch (error) {
+    console.warn('Unable to load previous state', error);
+  }
+  return deepClone(defaultState);
+}
+
+function persistState() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(appState));
+  } catch (error) {
+    console.warn('Unable to save state', error);
+    showToast('Unable to save changes (storage unavailable)');
+  }
+}
+
+function activateView(targetId, activeButton) {
+  if (!targetId && activeButton) {
+    targetId = activeButton.dataset.target;
+  }
+  if (!targetId) return;
+
+  navButtons.forEach((btn) => {
+    const isActive = btn === activeButton || btn.dataset.target === targetId;
+    btn.classList.toggle('nav__item--active', isActive);
+    if (isActive) {
+      btn.setAttribute('aria-current', 'page');
+    } else {
+      btn.removeAttribute('aria-current');
+    }
+  });
+
+  views.forEach((view) => {
+    view.classList.toggle('view--active', view.id === targetId);
+  });
+}
+
+function attachNavigationHandlers() {
+  navButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const targetId = button.dataset.target;
+      activateView(targetId, button);
+      appNav.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+    });
+  });
+}
+
+function attachMenuToggle() {
+  menuToggle.addEventListener('click', () => {
+    const isOpen = appNav.classList.toggle('open');
+    menuToggle.setAttribute('aria-expanded', String(isOpen));
+  });
+}
+
+function attachSessionFormHandlers() {
+  sessionForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const formData = new FormData(sessionForm);
+
+    const newSession = {
+      id: crypto.randomUUID ? crypto.randomUUID() : `session-${Date.now()}`,
+      date: formData.get('date'),
+      coach: formData.get('coach'),
+      coachee: formData.get('coachee'),
+      sessionType: formData.get('sessionType'),
+      focusArea: formData.get('focusArea'),
+      status: formData.get('status'),
+      duration: formData.get('duration') ? Number(formData.get('duration')) : null,
+      followUp: formData.get('followUp') || '',
+      highlights: formData.get('highlights')?.trim() || '',
+      actions: formData.get('actions')?.trim() || '',
+      createdAt: new Date().toISOString(),
+    };
+
+    appState.sessions = [newSession, ...appState.sessions];
+    persistState();
+    renderSessionList();
+    renderTodaySessions();
+    sessionForm.reset();
+    setDefaultFormValues();
+    showToast('Session saved');
+  });
+
+  sessionForm.addEventListener('reset', () => {
+    window.setTimeout(setDefaultFormValues, 0);
+  });
+}
+
+function attachQuickViewHandlers() {
+  quickRefreshButton.addEventListener('click', () => {
+    renderTodaySessions();
+    showToast('Today view refreshed');
+  });
+}
+
+function attachFilterHandlers() {
+  filterForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const formData = new FormData(filterForm);
+    currentFilters = {
+      coach: formData.get('coach') || '',
+      coachee: formData.get('coachee') || '',
+      status: formData.get('status') || '',
+      date: formData.get('date') || '',
+    };
+    renderSessionList();
+  });
+
+  clearFiltersButton.addEventListener('click', () => {
+    currentFilters = {
+      coach: '',
+      coachee: '',
+      status: '',
+      date: '',
+    };
+    filterForm.reset();
+    renderSessionList();
+  });
+}
+
+function attachExportHandler() {
+  exportJsonButton.addEventListener('click', () => {
+    const data = JSON.stringify(appState, null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `coaching-log-${new Date().toISOString().split('T')[0]}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    showToast('Exported data as JSON');
+  });
+}
+
+function setDefaultFormValues() {
+  const today = new Date().toISOString().split('T')[0];
+  sessionDateInput.value = today;
+  if (appState.referenceData.coaches.length > 0) {
+    sessionCoachSelect.value = sessionCoachSelect.value || appState.referenceData.coaches[0];
+  }
+  if (appState.referenceData.coachees.length > 0) {
+    sessionCoacheeSelect.value = sessionCoacheeSelect.value || appState.referenceData.coachees[0];
+  }
+  if (appState.referenceData.sessionTypes.length > 0) {
+    sessionTypeSelect.value = sessionTypeSelect.value || appState.referenceData.sessionTypes[0];
+  }
+  if (appState.referenceData.focusAreas.length > 0) {
+    sessionFocusSelect.value = sessionFocusSelect.value || appState.referenceData.focusAreas[0];
+  }
+  if (appState.referenceData.statuses.length > 0) {
+    sessionStatusSelect.value = sessionStatusSelect.value || appState.referenceData.statuses[0];
+  }
+}
+
+function refreshSelectOptions() {
+  fillSelect(sessionCoachSelect, appState.referenceData.coaches, {
+    placeholder: 'Select coach',
+    allowEmpty: false,
+  });
+  fillSelect(sessionCoacheeSelect, appState.referenceData.coachees, {
+    placeholder: 'Select coachee',
+    allowEmpty: false,
+  });
+  fillSelect(sessionTypeSelect, appState.referenceData.sessionTypes, {
+    placeholder: 'Select session type',
+    allowEmpty: false,
+  });
+  fillSelect(sessionFocusSelect, appState.referenceData.focusAreas, {
+    placeholder: 'Select focus area',
+    allowEmpty: false,
+  });
+  fillSelect(sessionStatusSelect, appState.referenceData.statuses, {
+    placeholder: 'Select status',
+    allowEmpty: false,
+  });
+
+  fillSelect(filterCoachSelect, appState.referenceData.coaches, {
+    placeholder: 'All coaches',
+    allowEmpty: true,
+  });
+  fillSelect(filterCoacheeSelect, appState.referenceData.coachees, {
+    placeholder: 'All coachees',
+    allowEmpty: true,
+  });
+  fillSelect(filterStatusSelect, appState.referenceData.statuses, {
+    placeholder: 'All statuses',
+    allowEmpty: true,
+  });
+}
+
+function fillSelect(select, options, { placeholder, allowEmpty }) {
+  const previousValue = select.value;
+  select.innerHTML = '';
+  if (allowEmpty) {
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = placeholder;
+    select.appendChild(option);
+  }
+  options.forEach((value) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = value;
+    select.appendChild(option);
+  });
+
+  if (!allowEmpty && options.length === 0) {
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = 'Add items from reference data';
+    select.appendChild(option);
+    select.disabled = true;
+    return;
+  }
+
+  select.disabled = options.length === 0 && !allowEmpty;
+  const hasPrevious = options.includes(previousValue);
+  if (hasPrevious) {
+    select.value = previousValue;
+  } else {
+    select.value = allowEmpty ? '' : options[0] || '';
+  }
+}
+
+function formatCount(count, config) {
+  const label = count === 1 ? config.singular.toLowerCase() : config.label.toLowerCase();
+  return `${count} ${label}`;
+}
+
+function renderReferenceSections() {
+  referenceSectionsEl.innerHTML = '';
+  Object.entries(categories).forEach(([key, config]) => {
+    const card = document.createElement('section');
+    card.className = 'reference-card';
+
+    const header = document.createElement('div');
+    header.className = 'reference-card__header';
+    const title = document.createElement('h2');
+    title.className = 'reference-card__title';
+    title.textContent = config.label;
+    const count = document.createElement('span');
+    count.className = 'reference-card__count';
+    count.textContent = formatCount(appState.referenceData[key].length, config);
+    header.append(title, count);
+    const description = document.createElement('p');
+    description.className = 'view__description';
+    description.textContent = config.description;
+    card.append(header, description);
+
+    const items = appState.referenceData[key];
+    if (items.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'quick-view__empty';
+      empty.textContent = 'No items yet. Add one below.';
+      card.append(empty);
+    } else {
+      const list = document.createElement('ul');
+      list.className = 'reference-card__list';
+      items.forEach((value) => {
+        const item = document.createElement('li');
+        item.className = 'reference-card__pill';
+        const text = document.createElement('span');
+        text.textContent = value;
+        const removeButton = document.createElement('button');
+        removeButton.type = 'button';
+        removeButton.setAttribute('aria-label', `Remove ${value}`);
+        removeButton.innerHTML = '×';
+        removeButton.addEventListener('click', () => {
+          if (isValueInUse(key, value)) {
+            showToast('Item is used in sessions and cannot be removed');
+            return;
+          }
+          const confirmed = confirm(`Remove "${value}" from ${config.label}?`);
+          if (!confirmed) return;
+          appState.referenceData[key] = appState.referenceData[key].filter((itemValue) => itemValue !== value);
+          persistState();
+          refreshSelectOptions();
+          renderReferenceSections();
+          showToast(`${config.singular} removed`);
+        });
+        item.append(text, removeButton);
+        list.appendChild(item);
+      });
+      card.append(list);
+    }
+
+    const form = document.createElement('form');
+    form.className = 'reference-card__form';
+    form.setAttribute('autocomplete', 'off');
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.required = true;
+    input.placeholder = config.addLabel;
+
+    const addButton = document.createElement('button');
+    addButton.type = 'submit';
+    addButton.className = 'button button--primary';
+    addButton.textContent = config.addLabel;
+
+    form.append(input, addButton);
+    card.append(form);
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const value = input.value.trim();
+      if (!value) return;
+      if (appState.referenceData[key].some((entry) => entry.toLowerCase() === value.toLowerCase())) {
+        showToast('That entry already exists');
+        return;
+      }
+      appState.referenceData[key] = [...appState.referenceData[key], value];
+      persistState();
+      input.value = '';
+      input.focus();
+      refreshSelectOptions();
+      renderReferenceSections();
+      showToast(`${config.singular} added`);
+    });
+
+    referenceSectionsEl.appendChild(card);
+  });
+}
+
+function isValueInUse(categoryKey, value) {
+  return appState.sessions.some((session) => {
+    switch (categoryKey) {
+      case 'coaches':
+        return session.coach === value;
+      case 'coachees':
+        return session.coachee === value;
+      case 'sessionTypes':
+        return session.sessionType === value;
+      case 'focusAreas':
+        return session.focusArea === value;
+      case 'statuses':
+        return session.status === value;
+      default:
+        return false;
+    }
+  });
+}
+
+function renderSessionList() {
+  sessionsList.innerHTML = '';
+  const filteredSessions = appState.sessions.filter((session) => {
+    if (currentFilters.coach && session.coach !== currentFilters.coach) return false;
+    if (currentFilters.coachee && session.coachee !== currentFilters.coachee) return false;
+    if (currentFilters.status && session.status !== currentFilters.status) return false;
+    if (currentFilters.date && session.date !== currentFilters.date) return false;
+    return true;
+  });
+
+  if (filteredSessions.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'quick-view__empty';
+    empty.textContent = 'No sessions match the filters yet.';
+    sessionsList.appendChild(empty);
+    return;
+  }
+
+  filteredSessions
+    .sort((a, b) => (a.date === b.date ? b.createdAt.localeCompare(a.createdAt) : b.date.localeCompare(a.date)))
+    .forEach((session) => {
+      const item = document.createElement('article');
+      item.className = 'timeline__item';
+
+      const title = document.createElement('h2');
+      title.textContent = `${session.coachee} with ${session.coach}`;
+      title.className = 'view__title';
+      title.style.fontSize = '1.1rem';
+
+      const meta = document.createElement('div');
+      meta.className = 'timeline__meta';
+      const dateSpan = document.createElement('span');
+      dateSpan.textContent = formatDisplayDate(session.date);
+      const durationSpan = document.createElement('span');
+      if (session.duration) {
+        durationSpan.textContent = `${session.duration} min`;
+      }
+      const followUpSpan = document.createElement('span');
+      if (session.followUp) {
+        followUpSpan.textContent = `Follow-up: ${formatDisplayDate(session.followUp)}`;
+      }
+      meta.append(dateSpan);
+      if (durationSpan.textContent) meta.append(durationSpan);
+      if (followUpSpan.textContent) meta.append(followUpSpan);
+
+      const tags = document.createElement('div');
+      tags.className = 'timeline__tags';
+      [session.sessionType, session.focusArea, session.status]
+        .filter(Boolean)
+        .forEach((tagText) => {
+          const tag = document.createElement('span');
+          tag.className = 'tag';
+          tag.textContent = tagText;
+          tags.appendChild(tag);
+        });
+
+      item.append(title);
+      item.append(meta);
+      if (tags.children.length > 0) {
+        item.append(tags);
+      }
+
+      if (session.highlights) {
+        const highlightsHeading = document.createElement('strong');
+        highlightsHeading.textContent = 'Highlights';
+        const highlights = document.createElement('p');
+        highlights.className = 'timeline__note';
+        highlights.textContent = session.highlights;
+        item.append(highlightsHeading, highlights);
+      }
+
+      if (session.actions) {
+        const actionsHeading = document.createElement('strong');
+        actionsHeading.textContent = 'Next actions';
+        const actions = document.createElement('p');
+        actions.className = 'timeline__note';
+        actions.textContent = session.actions;
+        item.append(actionsHeading, actions);
+      }
+
+      sessionsList.appendChild(item);
+    });
+}
+
+function renderTodaySessions() {
+  todaySessionsList.innerHTML = '';
+  const today = new Date().toISOString().split('T')[0];
+  const todaySessions = appState.sessions.filter((session) => session.date === today);
+
+  if (todaySessions.length === 0) {
+    todayEmptyState.hidden = false;
+    return;
+  }
+
+  todayEmptyState.hidden = true;
+  todaySessions.slice(0, 5).forEach((session) => {
+    const item = document.createElement('li');
+    item.className = 'quick-view__item';
+    const primary = document.createElement('div');
+    primary.className = 'quick-view__primary';
+    const name = document.createElement('strong');
+    name.textContent = session.coachee;
+    const detail = document.createElement('span');
+    detail.className = 'quick-view__detail';
+    detail.textContent = session.sessionType;
+    primary.append(name, detail);
+
+    const secondary = document.createElement('span');
+    secondary.className = 'quick-view__status';
+    secondary.textContent = session.status;
+
+    item.append(primary, secondary);
+    todaySessionsList.appendChild(item);
+  });
+}
+
+function showToast(message) {
+  toastEl.textContent = message;
+  toastEl.classList.add('show');
+  window.clearTimeout(showToast.timeoutId);
+  showToast.timeoutId = window.setTimeout(() => {
+    toastEl.classList.remove('show');
+  }, 2400);
+}
+
+function formatDisplayDate(date) {
+  if (!date) return '';
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }).format(new Date(date));
+  } catch (error) {
+    return date;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Coaching Session Log</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="app-header">
+        <div class="brand">
+          <span class="brand__title">Coaching Log</span>
+          <span class="brand__subtitle">Capture sessions in seconds</span>
+        </div>
+        <button
+          id="menu-toggle"
+          class="menu-toggle"
+          type="button"
+          aria-label="Open navigation"
+          aria-controls="app-nav"
+          aria-expanded="false"
+        >
+          <span class="menu-toggle__bar"></span>
+          <span class="menu-toggle__bar"></span>
+          <span class="menu-toggle__bar"></span>
+        </button>
+      </header>
+
+      <nav class="app-nav" id="app-nav" aria-label="Primary">
+        <button class="nav__item nav__item--active" type="button" data-target="log-view">
+          Log session
+        </button>
+        <button class="nav__item" type="button" data-target="reference-view">
+          Reference data
+        </button>
+        <button class="nav__item" type="button" data-target="sessions-view">
+          Sessions
+        </button>
+      </nav>
+
+      <main class="app-main">
+        <section id="log-view" class="view view--active" aria-labelledby="log-title">
+          <h1 id="log-title" class="view__title">Log a coaching session</h1>
+          <form id="session-form" class="card form">
+            <div class="form__row">
+              <label class="form__label" for="session-date">Session date</label>
+              <input id="session-date" name="date" type="date" required />
+            </div>
+
+            <div class="form__row">
+              <label class="form__label" for="session-coach">Coach</label>
+              <select id="session-coach" name="coach" required></select>
+            </div>
+
+            <div class="form__row">
+              <label class="form__label" for="session-coachee">Coachee</label>
+              <select id="session-coachee" name="coachee" required></select>
+            </div>
+
+            <div class="form__row">
+              <label class="form__label" for="session-type">Session type</label>
+              <select id="session-type" name="sessionType" required></select>
+            </div>
+
+            <div class="form__row">
+              <label class="form__label" for="session-focus">Focus area</label>
+              <select id="session-focus" name="focusArea" required></select>
+            </div>
+
+            <div class="form__row">
+              <label class="form__label" for="session-status">Status</label>
+              <select id="session-status" name="status" required></select>
+            </div>
+
+            <div class="form__row form__row--split">
+              <div>
+                <label class="form__label" for="session-duration">Duration (minutes)</label>
+                <input
+                  id="session-duration"
+                  name="duration"
+                  type="number"
+                  min="0"
+                  step="5"
+                  inputmode="numeric"
+                  placeholder="45"
+                />
+              </div>
+              <div>
+                <label class="form__label" for="session-follow-up">Follow-up date</label>
+                <input id="session-follow-up" name="followUp" type="date" />
+              </div>
+            </div>
+
+            <div class="form__row">
+              <label class="form__label" for="session-highlights">Highlights</label>
+              <textarea
+                id="session-highlights"
+                name="highlights"
+                rows="3"
+                placeholder="Key wins, progress, outcomes"
+              ></textarea>
+            </div>
+
+            <div class="form__row">
+              <label class="form__label" for="session-actions">Next actions</label>
+              <textarea
+                id="session-actions"
+                name="actions"
+                rows="3"
+                placeholder="Agreed next steps or homework"
+              ></textarea>
+            </div>
+
+            <div class="form__actions">
+              <button type="submit" class="button button--primary">
+                Save session
+              </button>
+              <button type="reset" class="button button--ghost">Clear</button>
+            </div>
+          </form>
+
+          <section class="card quick-view" aria-labelledby="quick-summary-title">
+            <div class="quick-view__header">
+              <h2 id="quick-summary-title">Today at a glance</h2>
+              <button id="quick-refresh" class="icon-button" type="button" aria-label="Refresh list">
+                ↻
+              </button>
+            </div>
+            <ul id="today-sessions" class="quick-view__list"></ul>
+            <p id="today-empty" class="quick-view__empty">No sessions logged for today yet.</p>
+          </section>
+        </section>
+
+        <section id="reference-view" class="view" aria-labelledby="reference-title">
+          <h1 id="reference-title" class="view__title">Manage reference data</h1>
+          <p class="view__description">
+            These lists power the options on the session form. Add new entries or archive ones you no longer use.
+          </p>
+
+          <div id="reference-sections" class="reference-grid"></div>
+        </section>
+
+        <section id="sessions-view" class="view" aria-labelledby="sessions-title">
+          <div class="sessions-header">
+            <div>
+              <h1 id="sessions-title" class="view__title">Session history</h1>
+              <p class="view__description">Search and filter past coaching conversations.</p>
+            </div>
+            <button id="export-json" class="button button--ghost" type="button">
+              Export JSON
+            </button>
+          </div>
+
+          <form id="filter-form" class="card form form--filters">
+            <div class="form__row">
+              <label class="form__label" for="filter-coach">Coach</label>
+              <select id="filter-coach" name="coach"></select>
+            </div>
+            <div class="form__row">
+              <label class="form__label" for="filter-coachee">Coachee</label>
+              <select id="filter-coachee" name="coachee"></select>
+            </div>
+            <div class="form__row">
+              <label class="form__label" for="filter-status">Status</label>
+              <select id="filter-status" name="status"></select>
+            </div>
+            <div class="form__row">
+              <label class="form__label" for="filter-date">Date</label>
+              <input id="filter-date" name="date" type="date" />
+            </div>
+            <div class="form__actions">
+              <button type="submit" class="button button--primary">Apply</button>
+              <button type="button" id="clear-filters" class="button button--ghost">
+                Clear
+              </button>
+            </div>
+          </form>
+
+          <div id="sessions-list" class="timeline"></div>
+        </section>
+      </main>
+    </div>
+    <div id="toast" role="status" aria-live="polite"></div>
+
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,545 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f6fa;
+  --card: #ffffff;
+  --primary: #1f7aec;
+  --primary-dark: #155bb0;
+  --primary-soft: rgba(31, 122, 236, 0.12);
+  --text: #1b1d21;
+  --text-subtle: #5a6072;
+  --border: #d9dce3;
+  --radius-lg: 18px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+  --shadow-soft: 0 16px 32px rgba(31, 122, 236, 0.08);
+  --shadow-card: 0 12px 24px rgba(27, 29, 33, 0.08);
+  --shadow-elevated: 0 18px 36px rgba(27, 29, 33, 0.14);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, rgba(31, 122, 236, 0.15), transparent 65%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(245, 246, 250, 0.8));
+  z-index: -1;
+}
+
+.app-shell {
+  width: min(960px, 100%);
+  padding: clamp(16px, 3vw, 32px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 2.5vw, 24px);
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--card);
+  padding: clamp(16px, 2vw, 20px) clamp(18px, 3vw, 28px);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  position: sticky;
+  top: clamp(12px, 2vw, 20px);
+  z-index: 3;
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.brand__title {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  font-size: clamp(1.1rem, 3vw, 1.4rem);
+}
+
+.brand__subtitle {
+  font-size: clamp(0.82rem, 2.2vw, 0.95rem);
+  color: var(--text-subtle);
+}
+
+.menu-toggle {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 0;
+  background: var(--primary-soft);
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  cursor: pointer;
+}
+
+.menu-toggle__bar {
+  width: 20px;
+  height: 3px;
+  background: var(--primary);
+  border-radius: 999px;
+}
+
+.app-nav {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  background: transparent;
+}
+
+.nav__item {
+  border: 0;
+  border-radius: var(--radius-md);
+  padding: 14px clamp(8px, 2vw, 16px);
+  font-weight: 600;
+  color: var(--text-subtle);
+  background: rgba(255, 255, 255, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.8), 0 10px 18px rgba(27, 29, 33, 0.04);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.nav__item:focus-visible {
+  outline: 3px solid rgba(31, 122, 236, 0.4);
+  outline-offset: 3px;
+}
+
+.nav__item:hover {
+  transform: translateY(-2px);
+}
+
+.nav__item--active {
+  background: var(--primary);
+  color: #fff;
+  box-shadow: var(--shadow-soft);
+}
+
+.app-main {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 28px);
+}
+
+.view {
+  display: none;
+  flex-direction: column;
+  gap: clamp(16px, 2.5vw, 24px);
+}
+
+.view--active {
+  display: flex;
+}
+
+.view__title {
+  font-size: clamp(1.3rem, 3vw, 1.6rem);
+  margin: 0;
+}
+
+.view__description {
+  margin: 0;
+  color: var(--text-subtle);
+  font-size: 0.95rem;
+}
+
+.card {
+  background: var(--card);
+  border-radius: var(--radius-lg);
+  padding: clamp(18px, 3vw, 26px);
+  box-shadow: var(--shadow-card);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.form__row {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.form__row--split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.form__label {
+  font-weight: 600;
+  color: var(--text-subtle);
+}
+
+input,
+select,
+textarea {
+  font: inherit;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(142, 147, 162, 0.4);
+  padding: 12px 14px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 1px 2px rgba(27, 29, 33, 0.05);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: rgba(31, 122, 236, 0.7);
+  box-shadow: 0 0 0 4px rgba(31, 122, 236, 0.12);
+}
+
+textarea {
+  resize: vertical;
+  min-height: 96px;
+}
+
+.form__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.button {
+  border-radius: 999px;
+  padding: 12px 20px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:focus-visible {
+  outline: 3px solid rgba(31, 122, 236, 0.4);
+  outline-offset: 2px;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+  color: #fff;
+  box-shadow: var(--shadow-soft);
+}
+
+.button--primary:active {
+  transform: scale(0.98);
+}
+
+.button--ghost {
+  background: rgba(31, 122, 236, 0.08);
+  color: var(--primary);
+}
+
+.icon-button {
+  background: rgba(31, 122, 236, 0.1);
+  border-radius: 999px;
+  border: none;
+  color: var(--primary);
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.icon-button:focus-visible {
+  outline: 3px solid rgba(31, 122, 236, 0.4);
+  outline-offset: 3px;
+}
+
+.quick-view {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.quick-view__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.quick-view__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.quick-view__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  background: rgba(31, 122, 236, 0.08);
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+}
+
+.quick-view__primary {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.quick-view__detail {
+  color: var(--text-subtle);
+  font-size: 0.85rem;
+}
+
+.quick-view__status {
+  background: rgba(31, 122, 236, 0.15);
+  color: var(--primary);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.quick-view__empty {
+  margin: 0;
+  color: var(--text-subtle);
+}
+
+.reference-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.reference-card {
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(31, 122, 236, 0.15), rgba(255, 255, 255, 0.8));
+  padding: 20px;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.reference-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.reference-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.reference-card__count {
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-weight: 600;
+}
+
+.reference-card__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.reference-card__pill {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 999px;
+  padding: 8px 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6), 0 8px 14px rgba(27, 29, 33, 0.05);
+}
+
+.reference-card__pill button {
+  border: none;
+  background: none;
+  color: var(--text-subtle);
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.reference-card__pill button:hover {
+  color: #d0021b;
+}
+
+.reference-card__form {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.reference-card__form input {
+  flex: 1;
+  min-width: 160px;
+}
+
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.timeline__item {
+  background: var(--card);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 8px;
+  border: 1px solid rgba(31, 122, 236, 0.08);
+}
+
+.timeline__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.93rem;
+  color: var(--text-subtle);
+}
+
+.timeline__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tag {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(31, 122, 236, 0.12);
+  color: var(--primary);
+  font-size: 0.85rem;
+}
+
+.timeline__note {
+  margin: 0;
+  color: var(--text);
+  white-space: pre-wrap;
+  line-height: 1.5;
+}
+
+.sessions-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.form--filters {
+  gap: 12px;
+}
+
+#toast {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translate(-50%, 120%);
+  background: rgba(27, 29, 33, 0.92);
+  color: #fff;
+  padding: 12px 18px;
+  border-radius: 999px;
+  box-shadow: var(--shadow-elevated);
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  pointer-events: none;
+  font-size: 0.95rem;
+}
+
+#toast.show {
+  transform: translate(-50%, 0);
+  opacity: 1;
+}
+
+@media (min-width: 640px) {
+  .reference-grid {
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    align-items: stretch;
+  }
+
+  .app-shell {
+    padding: 12px;
+    gap: 16px;
+  }
+
+  .app-header {
+    position: relative;
+    border-radius: var(--radius-md);
+  }
+
+  .menu-toggle {
+    display: flex;
+  }
+
+  .app-nav {
+    display: none;
+    grid-template-columns: 1fr;
+    gap: 12px;
+    background: transparent;
+  }
+
+  .app-nav.open {
+    display: grid;
+  }
+
+  .nav__item {
+    border-radius: var(--radius-md);
+    padding: 14px;
+  }
+
+  .form__row--split {
+    grid-template-columns: 1fr;
+  }
+
+  .sessions-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a mobile-first single page layout for logging sessions, managing reference lists, and browsing history
- implement client-side state with localStorage persistence, filtering, and JSON export for coaching sessions
- style the experience with responsive components optimized for small screens and document usage in the README

## Testing
- not run (static frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d0fd221340832d9f34aa516f181fc9