### PR TITLE
Set up GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload static files
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ A lightweight, mobile-friendly coaching session tracker that stores data locally
 - Vanilla HTML, CSS and JavaScript (no build step required)
 - Responsive layout optimized for phones and tablets
 - Local storage persistence
+
+## Deploying to GitHub Pages
+
+This project ships with a GitHub Actions workflow that publishes the static site straight to GitHub Pages from the `main` branch. To get it live:
+
+1. Push the repository to GitHub if you have not already.
+2. In the repository settings, open **Pages** and choose **GitHub Actions** as the source.
+3. Trigger the workflow by pushing to `main` (or run it manually from the **Actions** tab). The action uploads the contents of the repository and deploys them to Pages.
+
+Once the run finishes, the site will be available at the URL shown in the workflow summary (typically `https://<username>.github.io/<repo>`). Because all files are referenced with relative paths, no additional configuration is required for the hosted version.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that deploys the static site to GitHub Pages from the `main` branch
- document how to trigger the deployment and access the published site in the README

## Testing
- not run (static site project)


------
https://chatgpt.com/codex/tasks/task_e_68d10136c894832d94671af185f27f58