### PR TITLE
Add marketing site and admin auth shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,92 @@
 # Coaches Log
 
-A lightweight, mobile-friendly coaching session tracker that stores data locally in the browser. The main screen focuses on capturing a session quickly with pre-filled dropdowns that stay in sync with your reference data lists.
+A modern landing page and private admin workspace for managing basketball coaching sessions. Players see a sleek marketing site
+with a Calendly-powered booking widget while coaches unlock the original session tracker after signing in with Google or Apple.
 
-## Features
+## What's included
 
-- **Session logging** – Capture the essentials (date, coach, coachee, session type, focus area, status, duration, notes) with a single tap-friendly form.
-- **Reference data maintenance** – Manage coaches, coachees, session types, focus areas and statuses. Lists feed all dropdowns so the form always stays current.
-- **Session history** – Filter previous sessions by coach, coachee, status, or date and export everything as JSON for external reporting.
-- **Today view** – Glance at sessions scheduled or completed today without leaving the main screen.
-- **Offline-first** – All information is saved in `localStorage`; no backend services required.
+- **Marketing homepage** – Hero storytelling, achievements, training approach, testimonials, and contact details styled for a
+  basketball skills coach.
+- **Calendly booking widget** – An embedded scheduler (front and center on the hero) so athletes can immediately reserve a
+  1:1 training slot.
+- **Secure admin dashboard** – The previous local-first coaching log gated behind Firebase Authentication with Google and Apple
+  providers.
+- **Local persistence** – Session data, reference lists, and filters continue to live in `localStorage` in the admin view.
 
-## Getting started
+## Updating the Calendly link
 
-1. Open `index.html` in any modern browser (mobile Safari/Chrome supported).
-2. Add or edit reference data if needed (Reference data tab).
-3. Log a session from the main form – default options are pre-selected to accelerate data entry.
-4. Review or export the full history from the Sessions tab.
+Replace `YOUR-CALENDLY-USERNAME/60min` in `index.html` with the scheduling URL for your account:
 
-> Tip: To start fresh, clear the browser's site data or run the app in a private/incognito window.
+```html
+<div
+  class="calendly-inline-widget"
+  data-url="https://calendly.com/YOUR-CALENDLY-USERNAME/60min"
+  style="min-width: 320px; height: 660px"
+></div>
+```
+
+Calendly automatically resizes inside the styled container. Adjust the height if your appointment type needs more space.
+
+## Admin authentication setup
+
+Admin access relies on [Firebase Authentication](https://firebase.google.com/docs/auth) using Google and Apple providers. Until
+Firebase is configured, the login buttons are disabled and a reminder message appears on the modal.
+
+1. Create a Firebase project (or reuse an existing one) and enable Google and Apple sign-in under **Authentication → Sign-in
+   method**.
+2. Add the domain where the site is hosted (and `localhost` if testing locally) to **Authentication → Settings → Authorized
+domains**.
+3. If you plan to use Sign in with Apple, complete the Apple developer setup in Firebase and add the generated services ID.
+4. Copy your Firebase configuration snippet (found in **Project settings → General → Your apps**).
+5. Before the closing `</body>` in `index.html`, add a small script defining `window.COACHES_LOG_CONFIG` and update the allowed
+   admin emails:
+
+```html
+<script>
+  window.COACHES_LOG_CONFIG = {
+    firebase: {
+      apiKey: 'YOUR_FIREBASE_API_KEY',
+      authDomain: 'your-app.firebaseapp.com',
+      projectId: 'your-app',
+      appId: 'YOUR_FIREBASE_APP_ID'
+      // Optional: measurementId, storageBucket, etc.
+    },
+    adminEmails: ['you@example.com']
+  };
+</script>
+```
+
+Place this snippet **before** the existing `<script type="module" src="main.js"></script>` line so the configuration is available
+when the app initializes. Only signed-in users whose email matches `adminEmails` will see the dashboard. If you pass an empty
+array, any authenticated account is allowed.
+
+> Tip: Firebase popups require serving the site over `http://` or `https://`. Opening `index.html` directly from the file
+> system may block authentication. For local development, run a lightweight server (e.g. `npx serve` or `python -m http.server`).
+
+## Admin dashboard quick start
+
+After Firebase is configured and a coach signs in:
+
+1. Navigate to the **Log session** tab to capture new training notes.
+2. Update coaches, coachees, session types, focus areas, or statuses from the **Reference data** tab.
+3. Filter and export historical sessions from the **Sessions** tab.
+4. Data persists in the browser. Clear site data or open a private window to reset.
 
 ## Tech stack
 
-- Vanilla HTML, CSS and JavaScript (no build step required)
-- Responsive layout optimized for phones and tablets
-- Local storage persistence
-
-## Backend and data storage
-
-This project does not rely on a traditional backend service or remote database. All information that you enter is written to the
-browser's `localStorage` under the `coachesLogData` key. The data is stored as a JSON blob that contains two primary sections:
-
-- `referenceData` – arrays of the coaches, coachees, session types, focus areas, and statuses you manage from the Reference Data tab.
-- `sessions` – the individual coaching session records you log from the main form.
-
-Because the data stays entirely in the browser, clearing site data or using a different device will result in a fresh, empty
-application state. If you need to back up or migrate information, use the Sessions tab's export functionality to download the JSON
-and then import it into another browser instance.
+- Vanilla HTML, CSS, and JavaScript (no build tools required)
+- Google Fonts for typography and Calendly's inline widget
+- Firebase Authentication for Google and Apple sign-in
 
 ## Deploying to GitHub Pages
 
-This project ships with a GitHub Actions workflow that publishes the static site straight to GitHub Pages from the `main` branch. To get it live:
+This project ships with a GitHub Actions workflow that publishes the static site straight to GitHub Pages from the `main`
+branch:
 
 1. Push the repository to GitHub if you have not already.
 2. In the repository settings, open **Pages** and choose **GitHub Actions** as the source.
-3. Trigger the workflow by pushing to `main` (or run it manually from the **Actions** tab). The action uploads the contents of the repository and deploys them to Pages.
+3. Trigger the workflow by pushing to `main` (or run it manually from the **Actions** tab). The action uploads the contents of the
+   repository and deploys them to Pages.
 
-Once the run finishes, the site will be available at the URL shown in the workflow summary (typically `https://<username>.github.io/<repo>`). Because all files are referenced with relative paths, no additional configuration is required for the hosted version.
+After the workflow succeeds, update `window.COACHES_LOG_CONFIG` with your production Firebase credentials (and confirm the domain
+is authorized) so admin sign-in works on the hosted URL.

--- a/app.js
+++ b/app.js
@@ -88,7 +88,13 @@ const clearFiltersButton = document.getElementById('clear-filters');
 const sessionsList = document.getElementById('sessions-list');
 const exportJsonButton = document.getElementById('export-json');
 
-init();
+let initialized = false;
+
+export function initializeLogApp() {
+  if (initialized) return;
+  initialized = true;
+  init();
+}
 
 function init() {
   attachNavigationHandlers();

--- a/index.html
+++ b/index.html
@@ -3,196 +3,390 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Coaching Session Log</title>
+    <title>Coach Jaylen Carter | Elite Basketball Development</title>
     <link rel="stylesheet" href="styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      rel="preconnect"
-      href="https://fonts.gstatic.com"
-      crossorigin
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;700&family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
+    <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
   </head>
   <body>
-    <div class="app-shell">
-      <header class="app-header">
-        <div class="brand">
-          <span class="brand__title">Coaching Log</span>
-          <span class="brand__subtitle">Capture sessions in seconds</span>
+    <div class="site">
+      <header class="site-header">
+        <div class="site-header__brand">
+          <span class="brand-mark">Coach Jaylen Carter</span>
+          <span class="brand-tagline">Elite Basketball Skills Trainer</span>
         </div>
-        <button
-          id="menu-toggle"
-          class="menu-toggle"
-          type="button"
-          aria-label="Open navigation"
-          aria-controls="app-nav"
-          aria-expanded="false"
-        >
-          <span class="menu-toggle__bar"></span>
-          <span class="menu-toggle__bar"></span>
-          <span class="menu-toggle__bar"></span>
-        </button>
+        <nav class="site-header__actions">
+          <a class="site-link" href="#achievements">Achievements</a>
+          <a class="site-link" href="#approach">Training Approach</a>
+          <a class="site-link" href="#testimonials">Testimonials</a>
+          <button class="admin-link" type="button" data-open-login>Admin login</button>
+        </nav>
       </header>
 
-      <nav class="app-nav" id="app-nav" aria-label="Primary">
-        <button class="nav__item nav__item--active" type="button" data-target="log-view">
-          Log session
-        </button>
-        <button class="nav__item" type="button" data-target="reference-view">
-          Reference data
-        </button>
-        <button class="nav__item" type="button" data-target="sessions-view">
-          Sessions
-        </button>
-      </nav>
-
-      <main class="app-main">
-        <section id="log-view" class="view view--active" aria-labelledby="log-title">
-          <h1 id="log-title" class="view__title">Log a coaching session</h1>
-          <form id="session-form" class="card form">
-            <div class="form__row">
-              <label class="form__label" for="session-date">Session date</label>
-              <input id="session-date" name="date" type="date" required />
+      <main class="site-main">
+        <section class="hero" id="book">
+          <div class="hero__content">
+            <p class="hero__eyebrow">Personalized Player Development</p>
+            <h1 class="hero__title">Unlock next-level performance with Coach Jaylen</h1>
+            <p class="hero__description">
+              NCAA point guard turned professional skills coach. Jaylen Carter helps rising hoopers sharpen their handles,
+              elevate basketball IQ, and dominate every possession with game-speed reps tailored to their goals.
+            </p>
+            <div class="hero__cta">
+              <a class="button button--primary" href="#booking">Book a 1:1 session</a>
+              <button class="button button--ghost" type="button" data-open-login>Admin access</button>
             </div>
-
-            <div class="form__row">
-              <label class="form__label" for="session-coach">Coach</label>
-              <select id="session-coach" name="coach" required></select>
-            </div>
-
-            <div class="form__row">
-              <label class="form__label" for="session-coachee">Coachee</label>
-              <select id="session-coachee" name="coachee" required></select>
-            </div>
-
-            <div class="form__row">
-              <label class="form__label" for="session-type">Session type</label>
-              <select id="session-type" name="sessionType" required></select>
-            </div>
-
-            <div class="form__row">
-              <label class="form__label" for="session-focus">Focus area</label>
-              <select id="session-focus" name="focusArea" required></select>
-            </div>
-
-            <div class="form__row">
-              <label class="form__label" for="session-status">Status</label>
-              <select id="session-status" name="status" required></select>
-            </div>
-
-            <div class="form__row form__row--split">
-              <div>
-                <label class="form__label" for="session-duration">Duration (minutes)</label>
-                <input
-                  id="session-duration"
-                  name="duration"
-                  type="number"
-                  min="0"
-                  step="5"
-                  inputmode="numeric"
-                  placeholder="45"
-                />
-              </div>
-              <div>
-                <label class="form__label" for="session-follow-up">Follow-up date</label>
-                <input id="session-follow-up" name="followUp" type="date" />
-              </div>
-            </div>
-
-            <div class="form__row">
-              <label class="form__label" for="session-highlights">Highlights</label>
-              <textarea
-                id="session-highlights"
-                name="highlights"
-                rows="3"
-                placeholder="Key wins, progress, outcomes"
-              ></textarea>
-            </div>
-
-            <div class="form__row">
-              <label class="form__label" for="session-actions">Next actions</label>
-              <textarea
-                id="session-actions"
-                name="actions"
-                rows="3"
-                placeholder="Agreed next steps or homework"
-              ></textarea>
-            </div>
-
-            <div class="form__actions">
-              <button type="submit" class="button button--primary">
-                Save session
-              </button>
-              <button type="reset" class="button button--ghost">Clear</button>
-            </div>
-          </form>
-
-          <section class="card quick-view" aria-labelledby="quick-summary-title">
-            <div class="quick-view__header">
-              <h2 id="quick-summary-title">Today at a glance</h2>
-              <button id="quick-refresh" class="icon-button" type="button" aria-label="Refresh list">
-                ↻
-              </button>
-            </div>
-            <ul id="today-sessions" class="quick-view__list"></ul>
-            <p id="today-empty" class="quick-view__empty">No sessions logged for today yet.</p>
-          </section>
-        </section>
-
-        <section id="reference-view" class="view" aria-labelledby="reference-title">
-          <h1 id="reference-title" class="view__title">Manage reference data</h1>
-          <p class="view__description">
-            These lists power the options on the session form. Add new entries or archive ones you no longer use.
-          </p>
-
-          <div id="reference-sections" class="reference-grid"></div>
-        </section>
-
-        <section id="sessions-view" class="view" aria-labelledby="sessions-title">
-          <div class="sessions-header">
-            <div>
-              <h1 id="sessions-title" class="view__title">Session history</h1>
-              <p class="view__description">Search and filter past coaching conversations.</p>
-            </div>
-            <button id="export-json" class="button button--ghost" type="button">
-              Export JSON
-            </button>
+            <ul class="hero__highlights">
+              <li>
+                <strong>USA Basketball Gold License</strong>
+                <span>Certified trainer working with youth &amp; college athletes</span>
+              </li>
+              <li>
+                <strong>3× Conference Champion</strong>
+                <span>Leadership experience on the biggest stages</span>
+              </li>
+              <li>
+                <strong>Player Development Specialist</strong>
+                <span>Customized plans built from pro-level film study</span>
+              </li>
+            </ul>
           </div>
 
-          <form id="filter-form" class="card form form--filters">
-            <div class="form__row">
-              <label class="form__label" for="filter-coach">Coach</label>
-              <select id="filter-coach" name="coach"></select>
+          <div class="hero__booking" id="booking">
+            <div class="booking-card">
+              <h2 class="booking-card__title">Reserve your 1:1 training</h2>
+              <p class="booking-card__description">
+                Pick a time that fits your schedule. Sessions are hosted at the Southside Training Lab with options for on-site or
+                travel workouts.
+              </p>
+              <div class="calendly-card">
+                <div
+                  class="calendly-inline-widget"
+                  data-url="https://calendly.com/YOUR-CALENDLY-USERNAME/60min"
+                  style="min-width: 320px; height: 660px"
+                ></div>
+              </div>
             </div>
-            <div class="form__row">
-              <label class="form__label" for="filter-coachee">Coachee</label>
-              <select id="filter-coachee" name="coachee"></select>
-            </div>
-            <div class="form__row">
-              <label class="form__label" for="filter-status">Status</label>
-              <select id="filter-status" name="status"></select>
-            </div>
-            <div class="form__row">
-              <label class="form__label" for="filter-date">Date</label>
-              <input id="filter-date" name="date" type="date" />
-            </div>
-            <div class="form__actions">
-              <button type="submit" class="button button--primary">Apply</button>
-              <button type="button" id="clear-filters" class="button button--ghost">
-                Clear
-              </button>
-            </div>
-          </form>
+          </div>
+        </section>
 
-          <div id="sessions-list" class="timeline"></div>
+        <section class="section achievements" id="achievements">
+          <div class="section__header">
+            <h2>Signature accolades</h2>
+            <p>Proven success on the court and in the gym.</p>
+          </div>
+          <div class="cards-grid">
+            <article class="achievement-card">
+              <h3>All-State Guard</h3>
+              <p>Led Westview High to back-to-back state titles with 22 PPG, 8 APG, and 2.4 steals per game.</p>
+            </article>
+            <article class="achievement-card">
+              <h3>NCAA Floor General</h3>
+              <p>Started four years at Coastal State, finishing top-5 all time in assists and free-throw percentage.</p>
+            </article>
+            <article class="achievement-card">
+              <h3>Youth Development Leader</h3>
+              <p>Mentored 40+ athletes into college programs through AAU and high-performance summer intensives.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section approach" id="approach">
+          <div class="section__header">
+            <h2>Modern training that translates</h2>
+            <p>Every drill is anchored in film study, pace, and basketball IQ.</p>
+          </div>
+          <div class="approach-grid">
+            <article class="approach-card">
+              <h3>Game-speed reps</h3>
+              <p>High-intensity situational work that mirrors real defensive pressure and decision making.</p>
+            </article>
+            <article class="approach-card">
+              <h3>IQ &amp; film breakdowns</h3>
+              <p>Weekly film sessions that help athletes read the floor, attack mismatches, and lead with confidence.</p>
+            </article>
+            <article class="approach-card">
+              <h3>Strength &amp; mobility</h3>
+              <p>Custom mobility prep, core activation, and finishing strength tailored to each athlete's body.</p>
+            </article>
+            <article class="approach-card">
+              <h3>Season planning</h3>
+              <p>Progressive programming that keeps athletes fresh during long AAU and varsity campaigns.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section testimonials" id="testimonials">
+          <div class="section__header">
+            <h2>What players are saying</h2>
+            <p>Real results from athletes who train with Coach Jaylen.</p>
+          </div>
+          <div class="testimonial-grid">
+            <figure class="testimonial-card">
+              <blockquote>
+                “Coach Jaylen completely rebuilt my handle and shot mechanics. I earned my first varsity start within six weeks.”
+              </blockquote>
+              <figcaption>— Mia Rodriguez, Sophomore PG</figcaption>
+            </figure>
+            <figure class="testimonial-card">
+              <blockquote>
+                “The mix of skill work and game IQ changed everything. My recruitment blew up after his summer program.”
+              </blockquote>
+              <figcaption>— Carter Mills, AAU Wing</figcaption>
+            </figure>
+            <figure class="testimonial-card">
+              <blockquote>
+                “He keeps workouts fun but intense. Every session has a purpose and I can feel myself getting more confident.”
+              </blockquote>
+              <figcaption>— Jayda Lewis, Middle School Guard</figcaption>
+            </figure>
+          </div>
+        </section>
+
+        <section class="section connect" id="connect">
+          <div class="connect-card">
+            <h2>Training locations &amp; contact</h2>
+            <div class="connect-grid">
+              <div>
+                <h3>Gym availability</h3>
+                <ul>
+                  <li>Southside Training Lab — weekday evenings</li>
+                  <li>North Ridge Rec Center — weekend mornings</li>
+                  <li>Private court sessions available on request</li>
+                </ul>
+              </div>
+              <div>
+                <h3>Stay connected</h3>
+                <ul>
+                  <li>Email: <a href="mailto:coachjaylen@nextlevelskills.com">coachjaylen@nextlevelskills.com</a></li>
+                  <li>Instagram: <a href="https://instagram.com/coachjaylencarter" target="_blank" rel="noopener">@coachjaylencarter</a></li>
+                  <li>Phone: <a href="tel:+14045551234">(404) 555-1234</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
         </section>
       </main>
-    </div>
-    <div id="toast" role="status" aria-live="polite"></div>
 
-    <script type="module" src="app.js"></script>
+      <footer class="site-footer">
+        <p>&copy; <span id="copyright-year"></span> Coach Jaylen Carter. All rights reserved.</p>
+        <button class="site-footer__admin" type="button" data-open-login>Coach login</button>
+      </footer>
+    </div>
+
+    <section
+      class="admin-login"
+      id="admin-login"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="admin-login-title"
+      hidden
+    >
+      <div class="admin-login__panel">
+        <button class="admin-login__close" type="button" id="close-login" aria-label="Close admin sign-in">×</button>
+        <h2 id="admin-login-title">Admin access</h2>
+        <p id="login-instructions">Sign in to manage session logs and reference data.</p>
+        <div class="admin-login__buttons">
+          <button type="button" class="auth-button auth-button--google" data-auth-provider="google">
+            <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M21.6 12.23c0-.74-.06-1.28-.18-1.84H12v3.35h5.5c-.11.83-.7 2.08-2 2.92l-.02.13 2.9 2.21.2.02c1.84-1.7 2.9-4.2 2.9-6.79z" fill="#4285F4"/><path d="M12 22c2.7 0 4.96-.9 6.61-2.45l-3.15-2.4c-.84.58-1.97.99-3.46.99-2.65 0-4.9-1.78-5.7-4.24l-.12.01-3.08 2.38-.04.11C3.78 19.44 7.57 22 12 22z" fill="#34A853"/><path d="M6.3 13.9c-.2-.58-.32-1.2-.32-1.9s.12-1.32.3-1.9l-.01-.13-3.12-2.43-.1.05C2.3 9.03 2 10.48 2 12s.3 2.97.85 4.25l3.45-2.35z" fill="#FBBC05"/><path d="M12 7.6c1.87 0 3.14.8 3.87 1.47l2.82-2.74C16.93 4.2 14.67 3.2 12 3.2c-4.43 0-8.22 2.56-9.67 6.27l3.47 2.35C6.4 9.38 9.35 7.6 12 7.6z" fill="#EA4335"/></svg>
+            <span>Continue with Google</span>
+          </button>
+          <button type="button" class="auth-button auth-button--apple" data-auth-provider="apple">
+            <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M16.7 12.1c0-2.1 1.7-3.1 1.7-3.1-1-1.4-2.4-1.6-2.9-1.6-1.2-.1-2.3.7-2.9.7-.6 0-1.5-.7-2.5-.7-1.3 0-2.4.8-3.1 2.1-1.3 2.2-.3 5.4.9 7.2.6.9 1.4 1.9 2.4 1.8.9 0 1.2-.6 2.4-.6s1.4.6 2.4.6c1 .1 1.7-1 2.3-1.8.7-1 .9-1.9.9-1.9-.1 0-2-.7-2-3.7z"/><path d="M14.8 6.4c.5-.6.9-1.4.8-2.3-.8.1-1.6.5-2 .9-.4.4-.8 1.2-.7 2 .8.1 1.5-.3 1.9-.6z"/></svg>
+            <span>Continue with Apple</span>
+          </button>
+        </div>
+        <p class="admin-login__status" id="login-status" aria-live="polite"></p>
+        <p class="admin-login__error" id="login-error" role="alert"></p>
+        <p class="admin-login__footnote">Access reserved for authorized coaching staff.</p>
+      </div>
+    </section>
+
+    <section id="admin-app" class="admin-app" hidden aria-hidden="true">
+      <div class="admin-app__container">
+        <div class="admin-app__bar">
+          <div class="admin-app__identity">
+            <span class="admin-app__label">Signed in as</span>
+            <span class="admin-app__user" id="admin-user-name"></span>
+          </div>
+          <button class="button button--ghost admin-app__signout" type="button" id="sign-out-button">Sign out</button>
+        </div>
+
+        <div class="app-shell">
+          <header class="app-header">
+            <div class="brand">
+              <span class="brand__title">Coaching Log</span>
+              <span class="brand__subtitle">Capture sessions in seconds</span>
+            </div>
+            <button
+              id="menu-toggle"
+              class="menu-toggle"
+              type="button"
+              aria-label="Open navigation"
+              aria-controls="app-nav"
+              aria-expanded="false"
+            >
+              <span class="menu-toggle__bar"></span>
+              <span class="menu-toggle__bar"></span>
+              <span class="menu-toggle__bar"></span>
+            </button>
+          </header>
+
+          <nav class="app-nav" id="app-nav" aria-label="Primary">
+            <button class="nav__item nav__item--active" type="button" data-target="log-view">Log session</button>
+            <button class="nav__item" type="button" data-target="reference-view">Reference data</button>
+            <button class="nav__item" type="button" data-target="sessions-view">Sessions</button>
+          </nav>
+
+          <main class="app-main">
+            <section id="log-view" class="view view--active" aria-labelledby="log-title">
+              <h1 id="log-title" class="view__title">Log a coaching session</h1>
+              <form id="session-form" class="card form">
+                <div class="form__row">
+                  <label class="form__label" for="session-date">Session date</label>
+                  <input id="session-date" name="date" type="date" required />
+                </div>
+
+                <div class="form__row">
+                  <label class="form__label" for="session-coach">Coach</label>
+                  <select id="session-coach" name="coach" required></select>
+                </div>
+
+                <div class="form__row">
+                  <label class="form__label" for="session-coachee">Coachee</label>
+                  <select id="session-coachee" name="coachee" required></select>
+                </div>
+
+                <div class="form__row">
+                  <label class="form__label" for="session-type">Session type</label>
+                  <select id="session-type" name="sessionType" required></select>
+                </div>
+
+                <div class="form__row">
+                  <label class="form__label" for="session-focus">Focus area</label>
+                  <select id="session-focus" name="focusArea" required></select>
+                </div>
+
+                <div class="form__row">
+                  <label class="form__label" for="session-status">Status</label>
+                  <select id="session-status" name="status" required></select>
+                </div>
+
+                <div class="form__row form__row--split">
+                  <div>
+                    <label class="form__label" for="session-duration">Duration (minutes)</label>
+                    <input
+                      id="session-duration"
+                      name="duration"
+                      type="number"
+                      min="0"
+                      step="5"
+                      inputmode="numeric"
+                      placeholder="45"
+                    />
+                  </div>
+                  <div>
+                    <label class="form__label" for="session-follow-up">Follow-up date</label>
+                    <input id="session-follow-up" name="followUp" type="date" />
+                  </div>
+                </div>
+
+                <div class="form__row">
+                  <label class="form__label" for="session-highlights">Highlights</label>
+                  <textarea
+                    id="session-highlights"
+                    name="highlights"
+                    rows="3"
+                    placeholder="Key wins, progress, outcomes"
+                  ></textarea>
+                </div>
+
+                <div class="form__row">
+                  <label class="form__label" for="session-actions">Next actions</label>
+                  <textarea
+                    id="session-actions"
+                    name="actions"
+                    rows="3"
+                    placeholder="Agreed next steps or homework"
+                  ></textarea>
+                </div>
+
+                <div class="form__actions">
+                  <button type="submit" class="button button--primary">Save session</button>
+                  <button type="reset" class="button button--ghost">Clear</button>
+                </div>
+              </form>
+
+              <section class="card quick-view" aria-labelledby="quick-summary-title">
+                <div class="quick-view__header">
+                  <h2 id="quick-summary-title">Today at a glance</h2>
+                  <button id="quick-refresh" class="icon-button" type="button" aria-label="Refresh list">↻</button>
+                </div>
+                <ul id="today-sessions" class="quick-view__list"></ul>
+                <p id="today-empty" class="quick-view__empty">No sessions logged for today yet.</p>
+              </section>
+            </section>
+
+            <section id="reference-view" class="view" aria-labelledby="reference-title">
+              <h1 id="reference-title" class="view__title">Manage reference data</h1>
+              <p class="view__description">
+                These lists power the options on the session form. Add new entries or archive ones you no longer use.
+              </p>
+
+              <div id="reference-sections" class="reference-grid"></div>
+            </section>
+
+            <section id="sessions-view" class="view" aria-labelledby="sessions-title">
+              <div class="sessions-header">
+                <div>
+                  <h1 id="sessions-title" class="view__title">Session history</h1>
+                  <p class="view__description">Search and filter past coaching conversations.</p>
+                </div>
+                <button id="export-json" class="button button--ghost" type="button">Export JSON</button>
+              </div>
+
+              <form id="filter-form" class="card form form--filters">
+                <div class="form__row">
+                  <label class="form__label" for="filter-coach">Coach</label>
+                  <select id="filter-coach" name="coach"></select>
+                </div>
+                <div class="form__row">
+                  <label class="form__label" for="filter-coachee">Coachee</label>
+                  <select id="filter-coachee" name="coachee"></select>
+                </div>
+                <div class="form__row">
+                  <label class="form__label" for="filter-status">Status</label>
+                  <select id="filter-status" name="status"></select>
+                </div>
+                <div class="form__row">
+                  <label class="form__label" for="filter-date">Date</label>
+                  <input id="filter-date" name="date" type="date" />
+                </div>
+                <div class="form__actions">
+                  <button type="submit" class="button button--primary">Apply</button>
+                  <button type="button" id="clear-filters" class="button button--ghost">Clear</button>
+                </div>
+              </form>
+
+              <div id="sessions-list" class="timeline"></div>
+            </section>
+          </main>
+        </div>
+        <div id="toast" role="status" aria-live="polite"></div>
+      </div>
+    </section>
+
+    <script>
+      const yearEl = document.getElementById('copyright-year');
+      if (yearEl) {
+        yearEl.textContent = new Date().getFullYear();
+      }
+    </script>
+    <script type="module" src="main.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,290 @@
+import { initializeLogApp } from './app.js';
+
+const defaultConfig = {
+  firebase: {
+    apiKey: 'YOUR_FIREBASE_API_KEY',
+    authDomain: 'YOUR_FIREBASE_AUTH_DOMAIN',
+    projectId: 'YOUR_FIREBASE_PROJECT_ID',
+    appId: 'YOUR_FIREBASE_APP_ID',
+  },
+  adminEmails: ['coach@example.com'],
+};
+
+const globalConfig = window.COACHES_LOG_CONFIG || {};
+const firebaseConfig = {
+  ...defaultConfig.firebase,
+  ...(globalConfig.firebase || {}),
+};
+const adminEmails = Array.isArray(globalConfig.adminEmails) && globalConfig.adminEmails.length
+  ? globalConfig.adminEmails
+  : defaultConfig.adminEmails;
+
+const sanitizedAdminEmails = new Set(
+  adminEmails
+    .filter((email) => typeof email === 'string' && email.trim().length > 0)
+    .map((email) => email.trim().toLowerCase()),
+);
+
+const loginOverlay = document.getElementById('admin-login');
+const openLoginButtons = document.querySelectorAll('[data-open-login]');
+const closeLoginButton = document.getElementById('close-login');
+const loginStatus = document.getElementById('login-status');
+const loginError = document.getElementById('login-error');
+const loginInstructions = document.getElementById('login-instructions');
+const authButtons = document.querySelectorAll('[data-auth-provider]');
+const adminAppSection = document.getElementById('admin-app');
+const adminUserName = document.getElementById('admin-user-name');
+const signOutButton = document.getElementById('sign-out-button');
+
+let firebaseModules = null;
+let authInstance = null;
+let adminInitialized = false;
+let unauthorizedMessage = '';
+
+const firebaseConfigured = isFirebaseConfigured(firebaseConfig);
+
+updateLoginAvailability();
+
+if (firebaseConfigured) {
+  ensureFirebase().catch((error) => {
+    console.error('Authentication setup failed', error);
+    showLoginError('Unable to initialize sign-in. Check your Firebase configuration.');
+  });
+} else if (loginInstructions) {
+  loginInstructions.textContent =
+    'Connect Firebase Authentication to enable admin sign-in for the coaching dashboard.';
+}
+
+openLoginButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    clearMessages();
+    showLoginOverlay();
+  });
+});
+
+if (closeLoginButton) {
+  closeLoginButton.addEventListener('click', hideLoginOverlay);
+}
+
+if (loginOverlay) {
+  loginOverlay.addEventListener('click', (event) => {
+    if (event.target === loginOverlay) {
+      hideLoginOverlay();
+    }
+  });
+}
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && loginOverlay && !loginOverlay.hasAttribute('hidden')) {
+    hideLoginOverlay();
+  }
+});
+
+authButtons.forEach((button) => {
+  button.addEventListener('click', async () => {
+    if (!firebaseConfigured) return;
+    clearMessages();
+    button.classList.add('is-loading');
+    button.disabled = true;
+
+    try {
+      const modules = await ensureFirebase();
+      const provider =
+        button.dataset.authProvider === 'google'
+          ? new modules.GoogleAuthProvider()
+          : new modules.OAuthProvider('apple.com');
+
+      if (button.dataset.authProvider === 'google') {
+        provider.setCustomParameters({ prompt: 'select_account' });
+      } else {
+        provider.addScope('email');
+        provider.addScope('name');
+      }
+
+      await modules.signInWithPopup(authInstance, provider);
+      loginStatus.textContent = 'Signing you in…';
+    } catch (error) {
+      handleSignInError(error);
+    } finally {
+      button.classList.remove('is-loading');
+      button.disabled = false;
+    }
+  });
+});
+
+if (signOutButton) {
+  signOutButton.addEventListener('click', async () => {
+    try {
+      const modules = await ensureFirebase();
+      await modules.signOut(authInstance);
+      loginStatus.textContent = 'You have signed out.';
+      clearAdminDetails();
+      showLoginOverlay();
+    } catch (error) {
+      console.error('Sign out failed', error);
+      showLoginError('Sign out failed. Please try again.');
+    }
+  });
+}
+
+function isFirebaseConfigured(config) {
+  if (!config || typeof config !== 'object') return false;
+  const requiredKeys = ['apiKey', 'authDomain', 'projectId', 'appId'];
+  return requiredKeys.every((key) => {
+    const value = config[key];
+    return (
+      typeof value === 'string' &&
+      value.trim() !== '' &&
+      !/YOUR_|REPLACE_ME|EXAMPLE/.test(value)
+    );
+  });
+}
+
+function updateLoginAvailability() {
+  authButtons.forEach((button) => {
+    button.disabled = !firebaseConfigured;
+    button.setAttribute('aria-disabled', String(!firebaseConfigured));
+  });
+}
+
+function showLoginOverlay() {
+  if (!loginOverlay) return;
+  loginOverlay.removeAttribute('hidden');
+  loginOverlay.classList.add('is-visible');
+  document.body.classList.add('login-open');
+}
+
+function hideLoginOverlay() {
+  if (!loginOverlay) return;
+  loginOverlay.classList.remove('is-visible');
+  loginOverlay.setAttribute('hidden', '');
+  document.body.classList.remove('login-open');
+}
+
+function clearMessages() {
+  if (loginStatus) loginStatus.textContent = '';
+  if (loginError) loginError.textContent = '';
+}
+
+function showLoginError(message) {
+  if (loginError) {
+    loginError.textContent = message;
+  }
+}
+
+function clearAdminDetails() {
+  if (adminUserName) adminUserName.textContent = '';
+  if (adminAppSection) {
+    adminAppSection.setAttribute('hidden', '');
+    adminAppSection.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('admin-active');
+  }
+}
+
+async function ensureFirebase() {
+  if (firebaseModules) {
+    return firebaseModules;
+  }
+
+  if (!firebaseConfigured) {
+    throw new Error('Firebase is not configured.');
+  }
+
+  const [appMod, authMod] = await Promise.all([
+    import('https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js'),
+    import('https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js'),
+  ]);
+
+  const app = appMod.initializeApp(firebaseConfig);
+  authInstance = authMod.getAuth(app);
+  authInstance.useDeviceLanguage();
+  authMod.onAuthStateChanged(authInstance, handleAuthStateChange);
+
+  firebaseModules = {
+    ...authMod,
+    auth: authInstance,
+    GoogleAuthProvider: authMod.GoogleAuthProvider,
+    OAuthProvider: authMod.OAuthProvider,
+    signInWithPopup: authMod.signInWithPopup,
+    signOut: authMod.signOut,
+  };
+
+  return firebaseModules;
+}
+
+function handleAuthStateChange(user) {
+  if (!user) {
+    clearAdminDetails();
+    if (unauthorizedMessage) {
+      showLoginError(unauthorizedMessage);
+      unauthorizedMessage = '';
+      showLoginOverlay();
+    }
+    return;
+  }
+
+  if (!isAuthorized(user)) {
+    unauthorizedMessage = 'This account is not authorized to access the coaching dashboard.';
+    if (firebaseModules && authInstance) {
+      firebaseModules
+        .signOut(authInstance)
+        .catch((error) => console.error('Failed to clear unauthorized session', error));
+    }
+    return;
+  }
+
+  unauthorizedMessage = '';
+  showAdminApp(user);
+}
+
+function showAdminApp(user) {
+  if (!adminAppSection) return;
+
+  adminAppSection.removeAttribute('hidden');
+  adminAppSection.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('admin-active');
+
+  if (adminUserName) {
+    const displayName = user.displayName?.trim();
+    const email = user.email?.trim();
+    adminUserName.textContent = displayName || email || 'Coach Admin';
+  }
+
+  hideLoginOverlay();
+  clearMessages();
+
+  if (!adminInitialized) {
+    initializeLogApp();
+    adminInitialized = true;
+  }
+}
+
+function isAuthorized(user) {
+  if (!user) return false;
+  if (sanitizedAdminEmails.size === 0) return true;
+  const email = user.email ? user.email.toLowerCase() : '';
+  return sanitizedAdminEmails.has(email);
+}
+
+function handleSignInError(error) {
+  if (!error) return;
+  if (error.code === 'auth/popup-closed-by-user') {
+    showLoginError('Sign-in was cancelled before completion.');
+    return;
+  }
+  if (error.code === 'auth/cancelled-popup-request') {
+    showLoginError('Another sign-in attempt was in progress. Please try again.');
+    return;
+  }
+  if (error.code === 'auth/operation-not-supported-in-this-environment') {
+    showLoginError('Sign-in is not supported in this environment. Please open the site in a secure context.');
+    return;
+  }
+  if (error.code === 'auth/unauthorized-domain') {
+    showLoginError('The current domain is not authorized for this Firebase project.');
+    return;
+  }
+  console.error('Sign-in failed', error);
+  showLoginError('Unable to sign in. Please try again.');
+}
+

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,669 @@
 :root {
   color-scheme: light;
+  --font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-heading: 'Barlow Condensed', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --color-brand: #f97316;
+  --color-brand-dark: #ea580c;
+  --color-brand-soft: rgba(249, 115, 22, 0.18);
+  --color-surface: rgba(15, 23, 42, 0.66);
+  --color-surface-strong: rgba(15, 23, 42, 0.85);
+  --color-surface-light: rgba(15, 23, 42, 0.5);
+  --color-text-primary: #e2e8f0;
+  --color-text-muted: #94a3b8;
+  --color-panel: rgba(3, 7, 18, 0.75);
+  --color-border: rgba(148, 163, 184, 0.25);
+  --shadow-xl: 0 40px 90px rgba(2, 6, 23, 0.55);
+  --shadow-lg: 0 24px 60px rgba(15, 23, 42, 0.35);
+  --shadow-card: 0 20px 45px rgba(15, 23, 42, 0.25);
+  --radius-xl: 36px;
+  --radius-lg: 28px;
+  --radius-md: 20px;
+  --radius-sm: 14px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: radial-gradient(circle at 8% 12%, rgba(59, 130, 246, 0.24), transparent 55%),
+    radial-gradient(circle at 85% 18%, rgba(249, 115, 22, 0.22), transparent 60%), #030712;
+  color: var(--color-text-primary);
+  min-height: 100vh;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+button {
+  font: inherit;
+}
+
+body.login-open,
+body.admin-active {
+  overflow: hidden;
+}
+
+.site {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: clamp(1.2rem, 4vw, 2rem) clamp(1.5rem, 5vw, 3rem);
+  background: var(--color-panel);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.site-header__brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.brand-mark {
+  font-family: var(--font-heading);
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.brand-tagline {
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
+.site-header__actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: clamp(0.8rem, 2vw, 1.6rem);
+}
+
+.site-link {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.site-link:hover,
+.site-link:focus-visible {
+  color: var(--color-text-primary);
+}
+
+.admin-link {
+  border: 1px solid rgba(226, 232, 240, 0.4);
+  border-radius: 999px;
+  padding: 0.55rem 1.3rem;
+  background: transparent;
+  color: var(--color-text-primary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.admin-link:hover,
+.admin-link:focus-visible {
+  background: rgba(226, 232, 240, 0.12);
+  border-color: rgba(226, 232, 240, 0.6);
+}
+
+.site-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(4rem, 8vw, 6rem);
+  padding: 0 clamp(1.5rem, 5vw, 4rem) clamp(6rem, 10vw, 8rem);
+}
+
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: clamp(2.4rem, 5vw, 4.8rem);
+  padding: clamp(4rem, 8vw, 6rem) clamp(1.5rem, 6vw, 5rem);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(3, 7, 18, 0.92));
+  border-radius: 0 0 var(--radius-xl) var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(249, 115, 22, 0.35), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(59, 130, 246, 0.25), transparent 55%);
+  opacity: 0.65;
+  pointer-events: none;
+}
+
+.hero__content {
+  position: relative;
+  z-index: 1;
+  max-width: 560px;
+}
+
+.hero__eyebrow {
+  margin: 0 0 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.hero__title {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: clamp(2.6rem, 6vw, 4rem);
+  line-height: 1.05;
+  letter-spacing: 0.015em;
+  text-transform: uppercase;
+}
+
+.hero__description {
+  margin: clamp(1.2rem, 3vw, 1.8rem) 0 0;
+  color: rgba(226, 232, 240, 0.78);
+  font-size: 1.05rem;
+}
+
+.hero__cta {
+  margin-top: clamp(1.8rem, 4vw, 2.4rem);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.hero__highlights {
+  list-style: none;
+  margin: clamp(2rem, 4vw, 3rem) 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.hero__highlights li {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-md);
+  padding: 1.1rem 1.3rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.hero__highlights strong {
+  font-weight: 700;
+  color: #fff;
+}
+
+.hero__highlights span {
+  color: rgba(226, 232, 240, 0.7);
+  font-size: 0.95rem;
+}
+
+.hero__booking {
+  position: relative;
+  z-index: 1;
+}
+
+.booking-card {
+  background: rgba(15, 23, 42, 0.72);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.8rem, 4vw, 2.3rem);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow-card);
+  backdrop-filter: blur(18px);
+}
+
+.booking-card__title {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.booking-card__description {
+  margin: 1rem 0 1.5rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.calendly-card {
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(3, 7, 18, 0.6);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.section__header h2 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.section__header p {
+  margin: 0.6rem 0 0;
+  color: var(--color-text-muted);
+}
+
+.cards-grid {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.4rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.achievement-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.6rem, 3vw, 2.2rem);
+  border: 1px solid var(--color-border);
+  backdrop-filter: blur(14px);
+  box-shadow: var(--shadow-card);
+}
+
+.achievement-card h3 {
+  margin: 0 0 0.6rem;
+  font-size: 1.35rem;
+  color: #fff;
+}
+
+.achievement-card p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.approach {
+  position: relative;
+}
+
+.approach::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: var(--radius-xl);
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.88), rgba(3, 7, 18, 0.85));
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.approach > * {
+  position: relative;
+  z-index: 1;
+}
+
+.approach-grid {
+  display: grid;
+  gap: clamp(1.2rem, 3vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.approach-card {
+  padding: clamp(1.4rem, 3vw, 1.9rem);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow-card);
+}
+
+.approach-card h3 {
+  margin: 0 0 0.5rem;
+  color: #fff;
+  font-size: 1.25rem;
+}
+
+.approach-card p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.74);
+}
+
+.testimonial-grid {
+  display: grid;
+  gap: clamp(1.4rem, 3vw, 2.2rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.testimonial-card {
+  margin: 0;
+  padding: clamp(1.6rem, 3vw, 2.1rem);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  box-shadow: var(--shadow-card);
+}
+
+.testimonial-card blockquote {
+  margin: 0 0 1.1rem;
+  font-size: 1.05rem;
+  color: rgba(226, 232, 240, 0.86);
+}
+
+.testimonial-card figcaption {
+  color: rgba(248, 250, 252, 0.8);
+  font-weight: 600;
+}
+
+.connect-card {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.8rem, 3vw, 2.6rem);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow-card);
+}
+
+.connect-card h2 {
+  margin: 0 0 1.4rem;
+  font-family: var(--font-heading);
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.connect-grid {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.4rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.connect-card h3 {
+  margin: 0 0 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.connect-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.connect-card a {
+  color: #f8fafc;
+}
+
+.site-footer {
+  padding: clamp(1.5rem, 4vw, 2.2rem) clamp(1.5rem, 5vw, 3rem);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  color: rgba(226, 232, 240, 0.65);
+  background: rgba(2, 6, 23, 0.8);
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+  backdrop-filter: blur(12px);
+}
+
+.site-footer__admin {
+  border: 1px solid rgba(226, 232, 240, 0.4);
+  background: transparent;
+  color: var(--color-text-primary);
+  border-radius: 999px;
+  padding: 0.55rem 1.3rem;
+  cursor: pointer;
+}
+
+.site-footer__admin:hover,
+.site-footer__admin:focus-visible {
+  background: rgba(226, 232, 240, 0.12);
+}
+
+.button {
+  border-radius: 999px;
+  padding: 0.9rem 1.9rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.3s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.button:focus-visible {
+  outline: 3px solid rgba(249, 115, 22, 0.45);
+  outline-offset: 3px;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, var(--color-brand), var(--color-brand-dark));
+  color: #fff;
+  box-shadow: 0 22px 45px rgba(249, 115, 22, 0.35);
+}
+
+.button--primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 28px 55px rgba(249, 115, 22, 0.45);
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--color-text-primary);
+  border: 1px solid rgba(226, 232, 240, 0.5);
+}
+
+.button--ghost:hover {
+  background: rgba(226, 232, 240, 0.12);
+}
+
+.admin-login {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(2rem, 6vw, 4rem);
+  background: rgba(2, 6, 23, 0.75);
+  backdrop-filter: blur(20px);
+  z-index: 70;
+}
+
+.admin-login__panel {
+  position: relative;
+  width: min(420px, 92vw);
+  background: rgba(15, 23, 42, 0.94);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.8rem, 4vw, 2.4rem);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: var(--shadow-xl);
+}
+
+.admin-login__panel h2 {
+  margin: 0;
+  font-family: var(--font-heading);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.admin-login__panel p {
+  margin: 1rem 0 0;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.admin-login__buttons {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 1.6rem;
+}
+
+.auth-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.3s ease, background 0.2s ease;
+}
+
+.auth-button svg {
+  width: 22px;
+  height: 22px;
+}
+
+.auth-button--google {
+  background: #fff;
+  color: #111827;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.3);
+}
+
+.auth-button--google:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.35);
+}
+
+.auth-button--apple {
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+.auth-button--apple:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.4);
+}
+
+.auth-button.is-loading {
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.admin-login__close {
+  position: absolute;
+  top: 0.8rem;
+  right: 0.9rem;
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.admin-login__status {
+  margin-top: 1.2rem;
+  color: rgba(226, 232, 240, 0.8);
+  min-height: 1.2rem;
+}
+
+.admin-login__error {
+  margin: 0.6rem 0 0;
+  color: #fca5a5;
+  min-height: 1.2rem;
+}
+
+.admin-login__footnote {
+  margin-top: 1.6rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.admin-app {
+  position: fixed;
+  inset: 0;
+  padding: clamp(2rem, 6vw, 3.5rem);
+  background: linear-gradient(135deg, rgba(9, 12, 25, 0.94), rgba(3, 7, 18, 0.92));
+  z-index: 80;
+  overflow-y: auto;
+  display: flex;
+  justify-content: center;
+}
+
+.admin-app__container {
+  width: min(1080px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: rgba(255, 255, 255, 0.98);
+  border-radius: 32px;
+  box-shadow: var(--shadow-xl);
+  padding: clamp(1.5rem, 3vw, 2.4rem);
+}
+
+.admin-app__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(31, 122, 236, 0.15), rgba(31, 122, 236, 0.08));
+  padding: 1rem 1.4rem;
+}
+
+.admin-app__identity {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  color: #0f172a;
+}
+
+.admin-app__label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.admin-app__user {
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.admin-app__signout {
+  border: 1px solid rgba(31, 122, 236, 0.3);
+  color: #1f7aec;
+  background: rgba(31, 122, 236, 0.1);
+}
+
+.admin-app__signout:hover {
+  background: rgba(31, 122, 236, 0.18);
+}
+
+/* Admin application theme overrides */
+.admin-app {
   --bg: #f5f6fa;
   --card: #ffffff;
   --primary: #1f7aec;
@@ -14,40 +678,35 @@
   --shadow-soft: 0 16px 32px rgba(31, 122, 236, 0.08);
   --shadow-card: 0 12px 24px rgba(27, 29, 33, 0.08);
   --shadow-elevated: 0 18px 36px rgba(27, 29, 33, 0.14);
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
+.admin-app .button--primary {
+  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+  color: #fff;
+  box-shadow: var(--shadow-soft);
 }
 
-body {
-  margin: 0;
-  background: radial-gradient(circle at top, rgba(31, 122, 236, 0.15), transparent 65%),
-    var(--bg);
-  color: var(--text);
-  min-height: 100vh;
-  display: flex;
-  justify-content: center;
+.admin-app .button--primary:hover {
+  transform: translateY(-1px);
 }
 
-body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(245, 246, 250, 0.8));
-  z-index: -1;
+.admin-app .button--ghost {
+  background: rgba(31, 122, 236, 0.08);
+  color: var(--primary);
+  border: none;
+}
+
+.admin-app .button:focus-visible {
+  outline: 3px solid rgba(31, 122, 236, 0.4);
+  outline-offset: 2px;
 }
 
 .app-shell {
-  width: min(960px, 100%);
-  padding: clamp(16px, 3vw, 32px);
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: clamp(16px, 2.5vw, 24px);
+  position: relative;
 }
 
 .app-header {
@@ -59,7 +718,7 @@ body::before {
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-card);
   position: sticky;
-  top: clamp(12px, 2vw, 20px);
+  top: 0;
   z-index: 3;
 }
 
@@ -67,6 +726,7 @@ body::before {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  color: var(--text);
 }
 
 .brand__title {
@@ -120,11 +780,6 @@ body::before {
   transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
-.nav__item:focus-visible {
-  outline: 3px solid rgba(31, 122, 236, 0.4);
-  outline-offset: 3px;
-}
-
 .nav__item:hover {
   transform: translateY(-2px);
 }
@@ -154,6 +809,7 @@ body::before {
 .view__title {
   font-size: clamp(1.3rem, 3vw, 1.6rem);
   margin: 0;
+  color: var(--text);
 }
 
 .view__description {
@@ -221,35 +877,6 @@ textarea {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
-}
-
-.button {
-  border-radius: 999px;
-  padding: 12px 20px;
-  font-weight: 600;
-  border: none;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.button:focus-visible {
-  outline: 3px solid rgba(31, 122, 236, 0.4);
-  outline-offset: 2px;
-}
-
-.button--primary {
-  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
-  color: #fff;
-  box-shadow: var(--shadow-soft);
-}
-
-.button--primary:active {
-  transform: scale(0.98);
-}
-
-.button--ghost {
-  background: rgba(31, 122, 236, 0.08);
-  color: var(--primary);
 }
 
 .icon-button {
@@ -334,7 +961,7 @@ textarea {
 
 .reference-card {
   border-radius: var(--radius-lg);
-  background: linear-gradient(135deg, rgba(31, 122, 236, 0.15), rgba(255, 255, 255, 0.8));
+  background: linear-gradient(135deg, rgba(31, 122, 236, 0.15), rgba(255, 255, 255, 0.85));
   padding: 20px;
   box-shadow: var(--shadow-soft);
   display: flex;
@@ -351,6 +978,7 @@ textarea {
 .reference-card__title {
   margin: 0;
   font-size: 1.05rem;
+  color: var(--text);
 }
 
 .reference-card__count {
@@ -399,108 +1027,79 @@ textarea {
   flex-wrap: wrap;
 }
 
-.reference-card__form input {
-  flex: 1;
-  min-width: 160px;
-}
-
 .timeline {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: 16px;
 }
 
 .timeline__item {
-  background: var(--card);
-  border-radius: var(--radius-lg);
-  padding: 18px;
-  box-shadow: var(--shadow-soft);
   display: grid;
-  gap: 8px;
-  border: 1px solid rgba(31, 122, 236, 0.08);
+  gap: 10px;
+  padding: 18px;
+  border-radius: var(--radius-lg);
+  background: rgba(31, 122, 236, 0.08);
+  border: 1px solid rgba(31, 122, 236, 0.2);
+}
+
+.timeline__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.timeline__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text);
 }
 
 .timeline__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  font-size: 0.93rem;
   color: var(--text-subtle);
-}
-
-.timeline__tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.tag {
-  padding: 6px 12px;
-  border-radius: 999px;
-  background: rgba(31, 122, 236, 0.12);
-  color: var(--primary);
   font-size: 0.85rem;
 }
 
 .timeline__note {
   margin: 0;
-  color: var(--text);
-  white-space: pre-wrap;
-  line-height: 1.5;
+  color: var(--text-subtle);
 }
 
 .sessions-header {
   display: flex;
-  flex-wrap: wrap;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 16px;
 }
 
 .form--filters {
-  gap: 12px;
+  background: rgba(255, 255, 255, 0.9);
 }
 
 #toast {
   position: fixed;
-  left: 50%;
-  bottom: 24px;
-  transform: translate(-50%, 120%);
-  background: rgba(27, 29, 33, 0.92);
+  right: clamp(16px, 4vw, 32px);
+  bottom: clamp(16px, 4vw, 32px);
+  padding: 14px 20px;
+  border-radius: 14px;
+  background: rgba(31, 122, 236, 0.95);
   color: #fff;
-  padding: 12px 18px;
-  border-radius: 999px;
+  font-weight: 600;
   box-shadow: var(--shadow-elevated);
   opacity: 0;
-  transition: transform 0.3s ease, opacity 0.3s ease;
   pointer-events: none;
-  font-size: 0.95rem;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  transform: translateY(10px);
 }
 
 #toast.show {
-  transform: translate(-50%, 0);
   opacity: 1;
+  transform: translateY(0);
 }
 
-@media (min-width: 640px) {
-  .reference-grid {
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  }
-}
-
-@media (max-width: 720px) {
-  body {
-    align-items: stretch;
-  }
-
-  .app-shell {
-    padding: 12px;
-    gap: 16px;
-  }
-
+@media (max-width: 960px) {
   .app-header {
-    position: relative;
-    border-radius: var(--radius-md);
+    position: static;
   }
 
   .menu-toggle {
@@ -508,38 +1107,69 @@ textarea {
   }
 
   .app-nav {
-    display: none;
-    grid-template-columns: 1fr;
-    gap: 12px;
-    background: transparent;
+    position: absolute;
+    inset: auto 0 0;
+    margin-top: 8px;
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: var(--radius-lg);
+    padding: 12px;
+    box-shadow: var(--shadow-soft);
+    transform-origin: top;
+    transform: scaleY(0);
+    transition: transform 0.2s ease;
+    display: grid;
+    gap: 8px;
   }
 
   .app-nav.open {
-    display: grid;
-  }
-
-  .nav__item {
-    border-radius: var(--radius-md);
-    padding: 14px;
-  }
-
-  .form__row--split {
-    grid-template-columns: 1fr;
-  }
-
-  .sessions-header {
-    flex-direction: column;
-    align-items: stretch;
+    transform: scaleY(1);
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
+@media (max-width: 768px) {
+  .site-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.2rem;
+  }
+
+  .site-header__actions {
+    justify-content: flex-start;
+  }
+
+  .hero {
+    border-radius: 0 0 48px 48px;
+  }
+
+  .admin-app__container {
+    padding: 1.2rem;
+  }
+
+  .admin-app__bar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .admin-login__panel {
+    padding: 1.6rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .hero {
+    padding: 3.2rem 1.4rem;
+  }
+
+  .site-main {
+    padding: 0 1.4rem 5rem;
+  }
+
+  .button {
+    width: 100%;
+    text-align: center;
+  }
+
+  .admin-app__signout {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- replace the single-page app shell with a marketing homepage that showcases the coach and embeds a Calendly booking widget front and center
- add a Firebase-powered admin login overlay so only authorized Google or Apple accounts can open the existing coaching log dashboard
- refresh styles and documentation to explain the new configuration steps and keep the original tracker functional inside the gated admin view

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d10dcd0054832da0fc6767e9e98757