### PR TITLE
Allow admin dashboard without login

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
           <a class="site-link" href="#achievements">Achievements</a>
           <a class="site-link" href="#approach">Training Approach</a>
           <a class="site-link" href="#testimonials">Testimonials</a>
-          <button class="admin-link" type="button" data-open-login>Admin login</button>
+          <a class="admin-link" href="#admin-app" data-open-admin>Admin dashboard</a>
         </nav>
       </header>
 
@@ -39,7 +39,7 @@
             </p>
             <div class="hero__cta">
               <a class="button button--primary" href="#booking">Book a 1:1 session</a>
-              <button class="button button--ghost" type="button" data-open-login>Admin access</button>
+              <a class="button button--ghost" href="#admin-app" data-open-admin>Admin dashboard</a>
             </div>
             <ul class="hero__highlights">
               <li>
@@ -175,46 +175,16 @@
 
       <footer class="site-footer">
         <p>&copy; <span id="copyright-year"></span> Coach Jaylen Carter. All rights reserved.</p>
-        <button class="site-footer__admin" type="button" data-open-login>Coach login</button>
+        <a class="site-footer__admin" href="#admin-app" data-open-admin>Coach dashboard</a>
       </footer>
     </div>
-
-    <section
-      class="admin-login"
-      id="admin-login"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="admin-login-title"
-      hidden
-    >
-      <div class="admin-login__panel">
-        <button class="admin-login__close" type="button" id="close-login" aria-label="Close admin sign-in">×</button>
-        <h2 id="admin-login-title">Admin access</h2>
-        <p id="login-instructions">Sign in to manage session logs and reference data.</p>
-        <div class="admin-login__buttons">
-          <button type="button" class="auth-button auth-button--google" data-auth-provider="google">
-            <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M21.6 12.23c0-.74-.06-1.28-.18-1.84H12v3.35h5.5c-.11.83-.7 2.08-2 2.92l-.02.13 2.9 2.21.2.02c1.84-1.7 2.9-4.2 2.9-6.79z" fill="#4285F4"/><path d="M12 22c2.7 0 4.96-.9 6.61-2.45l-3.15-2.4c-.84.58-1.97.99-3.46.99-2.65 0-4.9-1.78-5.7-4.24l-.12.01-3.08 2.38-.04.11C3.78 19.44 7.57 22 12 22z" fill="#34A853"/><path d="M6.3 13.9c-.2-.58-.32-1.2-.32-1.9s.12-1.32.3-1.9l-.01-.13-3.12-2.43-.1.05C2.3 9.03 2 10.48 2 12s.3 2.97.85 4.25l3.45-2.35z" fill="#FBBC05"/><path d="M12 7.6c1.87 0 3.14.8 3.87 1.47l2.82-2.74C16.93 4.2 14.67 3.2 12 3.2c-4.43 0-8.22 2.56-9.67 6.27l3.47 2.35C6.4 9.38 9.35 7.6 12 7.6z" fill="#EA4335"/></svg>
-            <span>Continue with Google</span>
-          </button>
-          <button type="button" class="auth-button auth-button--apple" data-auth-provider="apple">
-            <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M16.7 12.1c0-2.1 1.7-3.1 1.7-3.1-1-1.4-2.4-1.6-2.9-1.6-1.2-.1-2.3.7-2.9.7-.6 0-1.5-.7-2.5-.7-1.3 0-2.4.8-3.1 2.1-1.3 2.2-.3 5.4.9 7.2.6.9 1.4 1.9 2.4 1.8.9 0 1.2-.6 2.4-.6s1.4.6 2.4.6c1 .1 1.7-1 2.3-1.8.7-1 .9-1.9.9-1.9-.1 0-2-.7-2-3.7z"/><path d="M14.8 6.4c.5-.6.9-1.4.8-2.3-.8.1-1.6.5-2 .9-.4.4-.8 1.2-.7 2 .8.1 1.5-.3 1.9-.6z"/></svg>
-            <span>Continue with Apple</span>
-          </button>
-        </div>
-        <p class="admin-login__status" id="login-status" aria-live="polite"></p>
-        <p class="admin-login__error" id="login-error" role="alert"></p>
-        <p class="admin-login__footnote">Access reserved for authorized coaching staff.</p>
-      </div>
-    </section>
-
-    <section id="admin-app" class="admin-app" hidden aria-hidden="true">
+    <section id="admin-app" class="admin-app" aria-labelledby="admin-app-title">
       <div class="admin-app__container">
         <div class="admin-app__bar">
           <div class="admin-app__identity">
-            <span class="admin-app__label">Signed in as</span>
-            <span class="admin-app__user" id="admin-user-name"></span>
+            <span class="admin-app__label" id="admin-app-title">Coach dashboard</span>
+            <span class="admin-app__user" id="admin-user-name">Admin access is temporarily open.</span>
           </div>
-          <button class="button button--ghost admin-app__signout" type="button" id="sign-out-button">Sign out</button>
         </div>
 
         <div class="app-shell">

--- a/main.js
+++ b/main.js
@@ -1,290 +1,41 @@
 import { initializeLogApp } from './app.js';
 
-const defaultConfig = {
-  firebase: {
-    apiKey: 'YOUR_FIREBASE_API_KEY',
-    authDomain: 'YOUR_FIREBASE_AUTH_DOMAIN',
-    projectId: 'YOUR_FIREBASE_PROJECT_ID',
-    appId: 'YOUR_FIREBASE_APP_ID',
-  },
-  adminEmails: ['coach@example.com'],
-};
-
-const globalConfig = window.COACHES_LOG_CONFIG || {};
-const firebaseConfig = {
-  ...defaultConfig.firebase,
-  ...(globalConfig.firebase || {}),
-};
-const adminEmails = Array.isArray(globalConfig.adminEmails) && globalConfig.adminEmails.length
-  ? globalConfig.adminEmails
-  : defaultConfig.adminEmails;
-
-const sanitizedAdminEmails = new Set(
-  adminEmails
-    .filter((email) => typeof email === 'string' && email.trim().length > 0)
-    .map((email) => email.trim().toLowerCase()),
-);
-
-const loginOverlay = document.getElementById('admin-login');
-const openLoginButtons = document.querySelectorAll('[data-open-login]');
-const closeLoginButton = document.getElementById('close-login');
-const loginStatus = document.getElementById('login-status');
-const loginError = document.getElementById('login-error');
-const loginInstructions = document.getElementById('login-instructions');
-const authButtons = document.querySelectorAll('[data-auth-provider]');
 const adminAppSection = document.getElementById('admin-app');
 const adminUserName = document.getElementById('admin-user-name');
-const signOutButton = document.getElementById('sign-out-button');
+const adminAccessTriggers = document.querySelectorAll('[data-open-admin]');
 
-let firebaseModules = null;
-let authInstance = null;
-let adminInitialized = false;
-let unauthorizedMessage = '';
-
-const firebaseConfigured = isFirebaseConfigured(firebaseConfig);
-
-updateLoginAvailability();
-
-if (firebaseConfigured) {
-  ensureFirebase().catch((error) => {
-    console.error('Authentication setup failed', error);
-    showLoginError('Unable to initialize sign-in. Check your Firebase configuration.');
-  });
-} else if (loginInstructions) {
-  loginInstructions.textContent =
-    'Connect Firebase Authentication to enable admin sign-in for the coaching dashboard.';
-}
-
-openLoginButtons.forEach((button) => {
-  button.addEventListener('click', () => {
-    clearMessages();
-    showLoginOverlay();
-  });
-});
-
-if (closeLoginButton) {
-  closeLoginButton.addEventListener('click', hideLoginOverlay);
-}
-
-if (loginOverlay) {
-  loginOverlay.addEventListener('click', (event) => {
-    if (event.target === loginOverlay) {
-      hideLoginOverlay();
-    }
-  });
-}
-
-document.addEventListener('keydown', (event) => {
-  if (event.key === 'Escape' && loginOverlay && !loginOverlay.hasAttribute('hidden')) {
-    hideLoginOverlay();
-  }
-});
-
-authButtons.forEach((button) => {
-  button.addEventListener('click', async () => {
-    if (!firebaseConfigured) return;
-    clearMessages();
-    button.classList.add('is-loading');
-    button.disabled = true;
-
-    try {
-      const modules = await ensureFirebase();
-      const provider =
-        button.dataset.authProvider === 'google'
-          ? new modules.GoogleAuthProvider()
-          : new modules.OAuthProvider('apple.com');
-
-      if (button.dataset.authProvider === 'google') {
-        provider.setCustomParameters({ prompt: 'select_account' });
-      } else {
-        provider.addScope('email');
-        provider.addScope('name');
-      }
-
-      await modules.signInWithPopup(authInstance, provider);
-      loginStatus.textContent = 'Signing you in…';
-    } catch (error) {
-      handleSignInError(error);
-    } finally {
-      button.classList.remove('is-loading');
-      button.disabled = false;
-    }
-  });
-});
-
-if (signOutButton) {
-  signOutButton.addEventListener('click', async () => {
-    try {
-      const modules = await ensureFirebase();
-      await modules.signOut(authInstance);
-      loginStatus.textContent = 'You have signed out.';
-      clearAdminDetails();
-      showLoginOverlay();
-    } catch (error) {
-      console.error('Sign out failed', error);
-      showLoginError('Sign out failed. Please try again.');
-    }
-  });
-}
-
-function isFirebaseConfigured(config) {
-  if (!config || typeof config !== 'object') return false;
-  const requiredKeys = ['apiKey', 'authDomain', 'projectId', 'appId'];
-  return requiredKeys.every((key) => {
-    const value = config[key];
-    return (
-      typeof value === 'string' &&
-      value.trim() !== '' &&
-      !/YOUR_|REPLACE_ME|EXAMPLE/.test(value)
-    );
-  });
-}
-
-function updateLoginAvailability() {
-  authButtons.forEach((button) => {
-    button.disabled = !firebaseConfigured;
-    button.setAttribute('aria-disabled', String(!firebaseConfigured));
-  });
-}
-
-function showLoginOverlay() {
-  if (!loginOverlay) return;
-  loginOverlay.removeAttribute('hidden');
-  loginOverlay.classList.add('is-visible');
-  document.body.classList.add('login-open');
-}
-
-function hideLoginOverlay() {
-  if (!loginOverlay) return;
-  loginOverlay.classList.remove('is-visible');
-  loginOverlay.setAttribute('hidden', '');
-  document.body.classList.remove('login-open');
-}
-
-function clearMessages() {
-  if (loginStatus) loginStatus.textContent = '';
-  if (loginError) loginError.textContent = '';
-}
-
-function showLoginError(message) {
-  if (loginError) {
-    loginError.textContent = message;
-  }
-}
-
-function clearAdminDetails() {
-  if (adminUserName) adminUserName.textContent = '';
-  if (adminAppSection) {
-    adminAppSection.setAttribute('hidden', '');
-    adminAppSection.setAttribute('aria-hidden', 'true');
-    document.body.classList.remove('admin-active');
-  }
-}
-
-async function ensureFirebase() {
-  if (firebaseModules) {
-    return firebaseModules;
-  }
-
-  if (!firebaseConfigured) {
-    throw new Error('Firebase is not configured.');
-  }
-
-  const [appMod, authMod] = await Promise.all([
-    import('https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js'),
-    import('https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js'),
-  ]);
-
-  const app = appMod.initializeApp(firebaseConfig);
-  authInstance = authMod.getAuth(app);
-  authInstance.useDeviceLanguage();
-  authMod.onAuthStateChanged(authInstance, handleAuthStateChange);
-
-  firebaseModules = {
-    ...authMod,
-    auth: authInstance,
-    GoogleAuthProvider: authMod.GoogleAuthProvider,
-    OAuthProvider: authMod.OAuthProvider,
-    signInWithPopup: authMod.signInWithPopup,
-    signOut: authMod.signOut,
-  };
-
-  return firebaseModules;
-}
-
-function handleAuthStateChange(user) {
-  if (!user) {
-    clearAdminDetails();
-    if (unauthorizedMessage) {
-      showLoginError(unauthorizedMessage);
-      unauthorizedMessage = '';
-      showLoginOverlay();
-    }
-    return;
-  }
-
-  if (!isAuthorized(user)) {
-    unauthorizedMessage = 'This account is not authorized to access the coaching dashboard.';
-    if (firebaseModules && authInstance) {
-      firebaseModules
-        .signOut(authInstance)
-        .catch((error) => console.error('Failed to clear unauthorized session', error));
-    }
-    return;
-  }
-
-  unauthorizedMessage = '';
-  showAdminApp(user);
-}
-
-function showAdminApp(user) {
+function revealAdminApp() {
   if (!adminAppSection) return;
 
   adminAppSection.removeAttribute('hidden');
   adminAppSection.setAttribute('aria-hidden', 'false');
-  document.body.classList.add('admin-active');
 
-  if (adminUserName) {
-    const displayName = user.displayName?.trim();
-    const email = user.email?.trim();
-    adminUserName.textContent = displayName || email || 'Coach Admin';
-  }
-
-  hideLoginOverlay();
-  clearMessages();
-
-  if (!adminInitialized) {
-    initializeLogApp();
-    adminInitialized = true;
+  if (adminUserName && adminUserName.textContent.trim().length === 0) {
+    adminUserName.textContent = 'Coach Admin';
   }
 }
 
-function isAuthorized(user) {
-  if (!user) return false;
-  if (sanitizedAdminEmails.size === 0) return true;
-  const email = user.email ? user.email.toLowerCase() : '';
-  return sanitizedAdminEmails.has(email);
+function focusAdminApp(event) {
+  if (!adminAppSection) return;
+
+  event.preventDefault();
+  adminAppSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
-function handleSignInError(error) {
-  if (!error) return;
-  if (error.code === 'auth/popup-closed-by-user') {
-    showLoginError('Sign-in was cancelled before completion.');
-    return;
-  }
-  if (error.code === 'auth/cancelled-popup-request') {
-    showLoginError('Another sign-in attempt was in progress. Please try again.');
-    return;
-  }
-  if (error.code === 'auth/operation-not-supported-in-this-environment') {
-    showLoginError('Sign-in is not supported in this environment. Please open the site in a secure context.');
-    return;
-  }
-  if (error.code === 'auth/unauthorized-domain') {
-    showLoginError('The current domain is not authorized for this Firebase project.');
-    return;
-  }
-  console.error('Sign-in failed', error);
-  showLoginError('Unable to sign in. Please try again.');
+function setupAdminAccess() {
+  adminAccessTriggers.forEach((trigger) => {
+    if (trigger.tagName.toLowerCase() === 'a') {
+      return;
+    }
+
+    trigger.addEventListener('click', focusAdminApp);
+  });
 }
 
+function init() {
+  revealAdminApp();
+  setupAdminAccess();
+  initializeLogApp();
+}
+
+init();


### PR DESCRIPTION
## Summary
- remove the Firebase login overlay and replace admin login buttons with direct dashboard links
- simplify the entry script to reveal the coaching dashboard immediately without authentication

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d111b8e8c4832d85016125f178de4a